### PR TITLE
Setup action to deploy on commits to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,34 @@
-name: Build and Deploy
+name: Build and Deploy Site to GitHub Pages
+
 on:
   push:
     branches:
       - master
-jobs:  
+
+jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-          
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-        
+
       - name: Install
         run: |
           npm install
           npm run dist
-          
+
       - name: Install SSH Client
-      - uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.
+        uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Build and Deploy Repo
-        uses: JamesIves/github-pages-deploy-action@releases/v3-test
+        uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          BASE_BRANCH: master   
+          BASE_BRANCH: master
           BRANCH: gh-pages
           FOLDER: www
           CLEAN: true


### PR DESCRIPTION
This sets up a GitHub Action to build and deploy the site on commits to master. It uses the [deploy-to-github-pages](https://github.com/marketplace/actions/deploy-to-github-pages) action which has a number of options. There's a few necessary [secrets to configure](https://github.com/marketplace/actions/deploy-to-github-pages#configuration-) to make this work.

This does rely on #2 as it uses `npm run dist` to build it.