### PR TITLE
Switch to using Front for inbound forms

### DIFF
--- a/static-src/scss/_theme.scss
+++ b/static-src/scss/_theme.scss
@@ -36,3 +36,16 @@ body {
     height: 100px;
   }
 }
+
+.inbound-form {
+  background-color: $primary;
+  color: $gray-100;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+
+  .form-container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: map-get($container-max-widths, "sm");
+  }
+}

--- a/www/advertisers.html
+++ b/www/advertisers.html
@@ -20,8 +20,8 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
         <div class="navbar-nav mr-auto">
-          <a class="nav-item nav-link" href="index.html">Home <span class="sr-only">(current)</span></a>
-          <a class="nav-item nav-link active" href="advertisers.html">Advertisers</a>
+          <a class="nav-item nav-link" href="index.html">Home</a>
+          <a class="nav-item nav-link active" href="advertisers.html">Advertisers <span class="sr-only">(current)</span></a>
           <a class="nav-item nav-link" href="publishers.html">Publishers</a>
         </div>
         <div class="navbar-nav justify-content-end">
@@ -39,7 +39,7 @@
           </h1>
           <h2>Get in front of a technical audience across an ecosystem of software-focused content</h2>
 
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdf-4nW9tWt_thXZcCKUvekdVCZOhWfAiIy3QADljL249AaWw/viewform?usp=sf_link" class="btn btn-warning shadow-none mt-2 mt-md-5">Become an advertiser today</a>
+          <a href="#inbound-form" class="btn btn-warning shadow-none mt-2 mt-md-5">Become an advertiser today</a>
         </div>
       </section>
 
@@ -102,7 +102,7 @@
             <p class="lead">
               You can see all our advertising information in our <a href="http://media.ethicalads.io/media/EthicalAds%20Advertising%20Prospectus%20Q3%202020.pdf">prospectus</a>.
               Once you read through that,
-              you can fill out our <a href="https://docs.google.com/forms/d/e/1FAIpQLSdf-4nW9tWt_thXZcCKUvekdVCZOhWfAiIy3QADljL249AaWw/viewform?usp=sf_link">advertiser signup</a> form to start the process.
+              you can fill out our <a href="#inbound-form">advertiser signup</a> form to start the process.
             </p>
           </div>
         </div>
@@ -126,12 +126,99 @@
 
       </section>
 
-      <section class="text-center d-flex flex-column justify-content-center">
+      <section class="inbound-form py-5" id="inbound-form">
         <div class="container">
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdf-4nW9tWt_thXZcCKUvekdVCZOhWfAiIy3QADljL249AaWw/viewform?usp=sf_link" class="btn btn-warning shadow-none">Become an advertiser today</a>
+          <div class="form-container">
+            <h4>Advertise across our network</h4>
+            <p>Start growing your business with our network today.</p>
+
+            <!-- Front - Advertiser Inquiry Form -->
+            <form
+              method="POST"
+              name="fa-form-1"
+              action="https://webhook.frontapp.com/forms/036c4169294f3b04abaa/Kj948M2jCSE2BGi1jdHUJIf19c60Sgyuz5pht5P-JZljD5fhGM5CVaK0t3rjLOZoXXMi5vU0OSPl4L0fjwr6UysZtRIZ5OyfEqjHDJFQsEenpUNT7c1EQtUbb5s"
+              enctype="multipart/form-data"
+              accept-charset="utf-8"
+            >
+              <div class="form-group">
+                <label for="name">Your name</label>
+                <input class="form-control" type="text" id="name" name="name" placeholder="Joe Advertiser" required>
+              </div>
+
+              <div class="form-group">
+                <label for="email">Your email</label>
+                <input class="form-control" type="email" id="email" name="email" placeholder="you@yourcompany.com" required>
+              </div>
+
+              <div class="form-group">
+                <label for="company">Your company</label>
+                <input class="form-control" type="text" id="company" name="company" required>
+              </div>
+
+              <div class="form-group">
+                <label>Geographic focus</label>
+
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="geography" value="US and Canada" id="geo-usca">
+                  <label class="form-check-label" for="geo-usca">US and Canada</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="geography" value="Europe" id="geo-eu">
+                  <label class="form-check-label" for="geo-eu">Europe</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="geography" value="Asia Pacific" id="geo-apac">
+                  <label class="form-check-label" for="geo-apac">Asia Pacific</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="geography" value="Other" id="geo-other">
+                  <label class="form-check-label" for="geo-other">Other (explain in comments)</label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label>Topic focus</label>
+
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Data science and machine learning" id="datascience">
+                  <label class="form-check-label" for="datascience">Data science and machine learning</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Backend web development" id="backend">
+                  <label class="form-check-label" for="backend">Backend web development</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Frontend web development" id="frontend">
+                  <label class="form-check-label" for="frontend">Frontend web development</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Security and privacy" id="security-privacy">
+                  <label class="form-check-label" for="security-privacy">Security and privacy</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="DevOps" id="devops">
+                  <label class="form-check-label" for="devops">DevOps</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Other (explain in comments)" id="other">
+                  <label class="form-check-label" for="other">Other (explain in comments)</label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label for="body">Comments</label>
+                <textarea class="form-control" id="body" name="body" required>I'm excited to advertise across the network</textarea>
+                <small class="form-text">Anything else you'd like us to know?</small>
+              </div>
+
+              <div class="form-group my-5">
+                <input type="submit" value="Advertise with us" class="btn btn-warning">
+                <small class="form-text">We take privacy seriously and we don't share your email. You aren't going to be added to any mailing lists.</small>
+              </div>
+            </form>
+          </div>
         </div>
       </section>
-
 
     </main>
 

--- a/www/contact-error/index.html
+++ b/www/contact-error/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <meta name="description" content="EthicalAds: A developer-focused, privacy-obsessed ad network from the fine folks at Read the Docs">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="../bundle/main.css">
+
+    <title>Contact Error | EthicalAds: A developer-focused, privacy-obsessed ad network</title>
+  </head>
+  <body>
+
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="index.html"><img src="../img/ethicalads-logo-blue.svg" alt="EthicalAds" /></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div class="navbar-nav mr-auto">
+          <a class="nav-item nav-link" href="../">Home</a>
+          <a class="nav-item nav-link" href="../advertisers.html">Advertisers</a>
+          <a class="nav-item nav-link active" href="../publishers.html">Publishers</a>
+        </div>
+        <div class="navbar-nav justify-content-end">
+          <a class="nav-item nav-link" href="https://server.ethicalads.io/">User Login</a>
+        </div>
+      </div>
+    </nav>
+
+    <main>
+
+      <section class="container">
+        <h1>Whoops - there was a problem reaching us</h1>
+
+        <p>Our email system couldn't process your note to us. Please email us at ads@readthedocs.org and we'll get back to you as soon as we can.</p>
+
+        <p><a href="../">Learn more about EthicalAds</a></p>
+
+      </section><!-- /.container -->
+
+
+    </main>
+
+    <script src="../bundle/bundle.js"></script>
+  </body>
+</html>

--- a/www/contact-success/index.html
+++ b/www/contact-success/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <meta name="description" content="EthicalAds: A developer-focused, privacy-obsessed ad network from the fine folks at Read the Docs">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="../bundle/main.css">
+
+    <title>Contact Success | EthicalAds: A developer-focused, privacy-obsessed ad network</title>
+  </head>
+  <body>
+
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="index.html"><img src="../img/ethicalads-logo-blue.svg" alt="EthicalAds" /></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div class="navbar-nav mr-auto">
+          <a class="nav-item nav-link" href="../">Home</a>
+          <a class="nav-item nav-link" href="../advertisers.html">Advertisers</a>
+          <a class="nav-item nav-link active" href="../publishers.html">Publishers</a>
+        </div>
+        <div class="navbar-nav justify-content-end">
+          <a class="nav-item nav-link" href="https://server.ethicalads.io/">User Login</a>
+        </div>
+      </div>
+    </nav>
+
+    <main>
+
+      <section class="container">
+        <h1>Thanks for reaching out</h1>
+
+        <p>We got your message and we'll get back to you as soon as we can.</p>
+
+        <p><a href="../">Read more about EthicalAds</a></p>
+
+      </section><!-- /.container -->
+
+
+    </main>
+
+    <script src="../bundle/bundle.js"></script>
+  </body>
+</html>

--- a/www/index.html
+++ b/www/index.html
@@ -179,7 +179,7 @@
           <div class="col-md-6 mb-3">
             <h4>Interested in ads on your site?</h4>
             <p class="lead">Our EthicalAds network is a great place to generate revenue while increasing the privacy of the internet. We value the work you do in the tech industry, and we are interested in partnering with projects that also believe privacy is important.</p>
-              <a href="https://docs.google.com/forms/d/e/1FAIpQLSedMQofQd9zdb_OOS_TNHRlhWdtEYOB-xkFkpL-53yoaTToww/viewform?usp=sf_link" class="btn btn-warning shadow-none">
+              <a href="publishers.html#inbound-form" class="btn btn-warning shadow-none">
                 <span class="fa fa-dollar"></span>
                 <span>Apply to be a publisher today</span>
               </a>
@@ -188,7 +188,7 @@
           <div class="col-md-6">
             <h4>Want to get in front of our audience?</h4>
             <p class="lead">Reach millions of developers instantly on our advertising network. We allow targeting by topics and geography, so that you reach the exact audience that you want. Want to reach Data Scientists in the US? We can do that.</p>
-              <a href="https://docs.google.com/forms/d/e/1FAIpQLSdf-4nW9tWt_thXZcCKUvekdVCZOhWfAiIy3QADljL249AaWw/viewform?usp=sf_link" class="btn btn-warning shadow-none">
+              <a href="advertisers.html#inbound-form" class="btn btn-warning shadow-none">
                 <span class="fa fa-bullhorn"></span>
                 <span>Start advertising today</span>
               </a>

--- a/www/publishers.html
+++ b/www/publishers.html
@@ -20,9 +20,9 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
         <div class="navbar-nav mr-auto">
-          <a class="nav-item nav-link" href="index.html">Home <span class="sr-only">(current)</span></a>
+          <a class="nav-item nav-link" href="index.html">Home</a>
           <a class="nav-item nav-link" href="advertisers.html">Advertisers</a>
-          <a class="nav-item nav-link active" href="publishers.html">Publishers</a>
+          <a class="nav-item nav-link active" href="publishers.html">Publishers <span class="sr-only">(current)</span></a>
         </div>
         <div class="navbar-nav justify-content-end">
           <a class="nav-item nav-link" href="https://server.ethicalads.io/">User Login</a>
@@ -37,7 +37,7 @@
             <span class="font-weight-light">Publishers</span></h1>
             <h2>Make money on your tech site without compromising your visitors' privacy.</h2>
 
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSedMQofQd9zdb_OOS_TNHRlhWdtEYOB-xkFkpL-53yoaTToww/viewform?usp=sf_link" class="btn btn-warning shadow-none mt-2 mt-md-5">Become a publisher today</a>
+            <a href="#inbound-form" class="btn btn-warning shadow-none mt-2 mt-md-5">Become a publisher today</a>
         </div>
       </section>
 
@@ -117,7 +117,7 @@
           <div class="col-md-6 mb-3">
             <h4>How do I get started?</h4>
             <p>
-              Simply fill out our <a href="https://docs.google.com/forms/d/e/1FAIpQLSedMQofQd9zdb_OOS_TNHRlhWdtEYOB-xkFkpL-53yoaTToww/viewform?usp=sf_link">publisher signup</a> form with some information, and we'll get back to you right away.
+              Simply fill out our <a href="#inbound-form">publisher signup</a> form with some information, and we'll get back to you right away.
             </p>
           </div>
           <div class="col-md-6">
@@ -165,12 +165,84 @@
       </section>
 
 
-      <section class="text-center d-flex flex-column justify-content-center">
+      <section class="inbound-form py-5" id="inbound-form">
         <div class="container">
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSedMQofQd9zdb_OOS_TNHRlhWdtEYOB-xkFkpL-53yoaTToww/viewform?usp=sf_link" class="btn btn-warning shadow-none">Become a publisher today</a>
+          <div class="form-container">
+            <h4>Become a publisher today</h4>
+            <p>Tell us more about you and your site and we'll get back to you about joining our EthicalAds network.</p>
+
+            <!-- Front - Publisher Inquiry Form -->
+            <form
+              method="POST"
+              name="fa-form-1"
+              action="https://webhook.frontapp.com/forms/036c4169294f3b04abaa/LhIhHSWLrHiPkcH2jWPX0h2JxpZ1DxV3JMNMHDZaIGf6LdI5zoIK6S2kf9Uc7WWLaCpB7XD06OKLEepCnuv65gQGJaFG9QFD8mvAsxwhUudx-8X1IJXT2rQJuPg"
+              enctype="multipart/form-data"
+              accept-charset="utf-8"
+            >
+              <div class="form-group">
+                <label for="name">Your name</label>
+                <input class="form-control" type="text" id="name" name="name" placeholder="Joe Publisher" required>
+              </div>
+
+              <div class="form-group">
+                <label for="email">Your email</label>
+                <input class="form-control" type="email" id="email" name="email" placeholder="you@yourwebsite.com" required>
+              </div>
+
+              <div class="form-group">
+                <label for="website">Your site</label>
+                <input class="form-control" type="text" id="website" name="website" placeholder="yourwebsite.com" required>
+              </div>
+
+              <div class="form-group">
+                <label for="pageviews">Average monthly pageviews</label>
+                <input class="form-control" type="text" id="pageviews" name="pageviews" placeholder="50k" required>
+                <small class="form-text">On an average month how many pageviews does your site do?</small>
+              </div>
+
+              <div class="form-group">
+                <label>Audience category</label>
+
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Data science and machine learning" id="datascience">
+                  <label class="form-check-label" for="datascience">Data science and machine learning</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Backend web development" id="backend">
+                  <label class="form-check-label" for="backend">Backend web development</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Frontend web development" id="frontend">
+                  <label class="form-check-label" for="frontend">Frontend web development</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Security and privacy" id="security-privacy">
+                  <label class="form-check-label" for="security-privacy">Security and privacy</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="DevOps" id="devops">
+                  <label class="form-check-label" for="devops">DevOps</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="audience" value="Other (explain in comments)" id="other">
+                  <label class="form-check-label" for="other">Other (explain in comments)</label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label for="body">Comments</label>
+                <textarea class="form-control" id="body" name="body" required>I'm excited to join the network</textarea>
+                <small class="form-text">Anything else you'd like us to know?</small>
+              </div>
+
+              <div class="form-group my-5">
+                <input type="submit" value="Become a publisher" class="btn btn-warning">
+                <small class="form-text">We take privacy seriously and we don't share your email. You aren't going to be added to any mailing lists.</small>
+              </div>
+            </form>
+          </div>
         </div>
       </section>
-
 
     </main>
 


### PR DESCRIPTION
- This keeps emails and info in one place Front instead of Front and Google Forms
- Keeps people on our site and should have higher conversions
- On form submit, the user gets redirected to `contact-success/` or `contact-error/`. These have very short pages.

**IMPORTANT BEFORE MERGING** These forms perform referrer checking. This referrer is set to `localhost:5000` for testing but needs to be updated for production.

## Testing

* `npm install && npm run build`
* `cd www/ && python3 -m http.server 5000`
* Go to http://localhost:5000/advertisers.html#inbound-form and submit the form
* See the result in the Ads inbox in Front.
* Do the same for the publisher form: http://localhost:5000/publishers.html#inbound-form


## Screenshot

![Screen Shot 2020-07-16 at 2 02 03 PM](https://user-images.githubusercontent.com/185043/87722481-0657c700-c76d-11ea-863e-d8bfaffc5f18.png)
