### PR TITLE
Emphasize advertisers in the header

### DIFF
--- a/ethicalads-theme/templates/includes/footer.html
+++ b/ethicalads-theme/templates/includes/footer.html
@@ -3,10 +3,9 @@
   <div>
     <ul class="list-inline">
       <li class="list-inline-item small">&copy; 2020 Read the Docs, Inc.</li>
-      <li class="list-inline-item small"><a href="https://readthedocs.org">Read the Docs</a></li>
       <li class="list-inline-item small"><a href="/privacy-policy/">Privacy Policy</a></li>
       <li class="list-inline-item small"><a href="/publisher-policy/">Publisher Policy</a></li>
-      <li class="list-inline-item float-right small"><a href="https://server.ethicalads.io">Login</a></li>
+      <li class="list-inline-item small"><a href="https://server.ethicalads.io">Publisher &amp; Advertiser Login</a></li>
     </ul>
   </div>
 </footer>

--- a/ethicalads-theme/templates/includes/navigation.html
+++ b/ethicalads-theme/templates/includes/navigation.html
@@ -4,25 +4,25 @@
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-    <div class="navbar-nav mr-auto">
-
+    <div class="ml-auto navbar-nav justify-content-end">
       {% if DISPLAY_PAGES_ON_MENU %}
         {% for p in pages %}
           <a class="nav-item nav-link {% if p == page %}active{% endif %}" href="/{{ p.url }}">{{ p.title }} {% if p == page %}<span class="sr-only">(current)</span>{% endif %}</a>
         {% endfor %}
       {% endif %}
+
       {% if DISPLAY_CATEGORIES_ON_MENU %}
         {% for cat, null in categories %}
           <a class="nav-item nav-link {% if cat == category %}active{% endif %}" href="/{{ cat.url }}">{{ cat }} {% if cat == category %}<span class="sr-only">(current)</span>{% endif %}</a>
         {% endfor %}
       {% endif %}
+
       {% for title, link in MENUITEMS %}
         <a class="nav-item nav-link" href="{{ link }}">{{ title }}</a>
       {% endfor %}
-    </div>
-    <div class="navbar-nav justify-content-end">
-      {% for title, link in MENUITEMS_RIGHT %}
-        <a class="nav-item nav-link" href="{{ link }}">{{ title }}</a>
+
+      {% for title, link in MENUITEMS_CTA %}
+        <a class="nav-item btn btn-outline-primary" href="{{ link }}">{{ title }}</a>
       {% endfor %}
     </div>
   </div>

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -48,12 +48,14 @@ AUTHOR_FEED_RSS = None
 
 # Menu settings
 # --------------------------------------------------------------------------
-DISPLAY_PAGES_ON_MENU = True
+DISPLAY_PAGES_ON_MENU = False
 DISPLAY_CATEGORIES_ON_MENU = False
 MENUITEMS = [
-    ('Blog', '/blog/'),
+    ("Login", "https://server.ethicalads.io/"),
+    ("Blog", "/blog/"),
+    ("Join EthicalAds", "/publishers/"),
 ]
-MENUITEMS_RIGHT = [("User Login", "https://server.ethicalads.io/")]
+MENUITEMS_CTA = [("Advertise with Us", "/advertisers/")]
 
 # URL settings
 # https://docs.getpelican.com/en/stable/settings.html#url-settings


### PR DESCRIPTION
- Move all links to the right
- Manage the top header manually rather than "show pages in header". This allows controlling the order

## Screenshots

![Screen Shot 2020-08-26 at 1 45 46 PM](https://user-images.githubusercontent.com/185043/91355088-89276500-e7a2-11ea-8c18-1d363913c181.png)
![Screen Shot 2020-08-26 at 1 46 18 PM](https://user-images.githubusercontent.com/185043/91355093-8a589200-e7a2-11ea-8e25-e3b0cae6a906.png)
(the menu is expanded in this picture, it defaults to collapsed)