### PR TITLE
Point to the beta ads client

### DIFF
--- a/ethicalads-theme/templates/ea/homepage.html
+++ b/ethicalads-theme/templates/ea/homepage.html
@@ -5,7 +5,7 @@
 {{ super() }}
 
 {# Ad Client #}
-<script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
+<script async src="https://media.ethicalads.io/media/client/beta/ethicalads.min.js"></script>
 {% endblock head %}
 
 


### PR DESCRIPTION
The new beta ads client contains viewport detection (https://github.com/readthedocs/ethical-ad-client/pull/29).

With our current implementation, the pixel will be added twice. The first time is because the pixel is included in the HTML response for the ad from the server. Once viewport detection is properly rolled out, this can be removed. The second time the pixel is loaded by the client directly.

Since on our marketing site the ad is below the fold, this allows us to test the client. This also gives us a public URL for the beta client to help facilitate testing the client on other publishers.