### PR TITLE
Learning hub soft launch

### DIFF
--- a/content/pages/learning-hub/advertiser-guide.md
+++ b/content/pages/learning-hub/advertiser-guide.md
@@ -66,7 +66,7 @@ These are not real ads that ran on the EthicalAds network but are based on very
 successful past ads.
 ​
 ### SaaS product
-![](../images/pages/learning-hub/successful-ad-2.png)
+![A successful SaaS product ad on the EthicalAds network](../images/pages/learning-hub/successful-ad-2.png){style="width: 100%"}
 ​
 
 This example is based on a successful ad run by an advertiser
@@ -79,7 +79,7 @@ objections that somebody who needs sales reports from their Django app
 might have.
 ​
 ### Hiring developers
-![](../images/pages/learning-hub/successful-ad-1.png)
+![A successful ad aimed at hiring developers on the EthicalAds network](../images/pages/learning-hub/successful-ad-1.png){style="width: 100%"}
 
 ​
 This example is based on a successful ad run by an advertiser using

--- a/content/pages/publisher-policy.md
+++ b/content/pages/publisher-policy.md
@@ -34,7 +34,7 @@ You are also welcome to show EthicalAds to a share of your visitors (eg. 50%) al
 
 
 We currently have a **70% revenue share** with publishers
-which is around industry standard but slightly higher. 
+which is around industry standard but slightly higher.
 This means you get 70% of the money that we make.
 
 We handle payouts once a month,

--- a/content/pages/vision.md
+++ b/content/pages/vision.md
@@ -101,13 +101,13 @@ and ensure that they bring the kind of audience our advertisers want to reach.
 
 ## Community Ads
 
-We also give our publishers the ability to give back to the community by promoting worthy, relevant causes. There are a large number of projects, conferences, and initiatives that we care about in the software and open source ecosystems. A large number of them operate with almost no income. Our optional Community Ads program highlights these projects by running ad campaigns at no cost. 
+We also give our publishers the ability to give back to the community by promoting worthy, relevant causes. There are a large number of projects, conferences, and initiatives that we care about in the software and open source ecosystems. A large number of them operate with almost no income. Our optional Community Ads program highlights these projects by running ad campaigns at no cost.
 
 There are a few qualifications for our Community Ads program:
 
 * Your organization and the linked site should not be trying to entice visitors to buy a product or service. We make an exception for conferences around open source projects if they are run not for profit and soliciting donations for open source projects.
 * A software project should have an [OSI approved license](https://opensource.org/licenses).
-* We will not run a community ad for an organization tied to one of our paid advertisers.  
+* We will not run a community ad for an organization tied to one of our paid advertisers.
 
 Please [complete an application](https://docs.google.com/forms/d/e/1FAIpQLSdd9LDska1eiDHWHs4No-8AlqjDxsUuP_zSBTeYyl5tMcBeFQ/viewform?usp=sf_link) to be considered for our Community Ads program. If you have any questions about our community ads program, feel free to [send us an email](mailto:ads@readthedocs.org).
 

--- a/content/posts/newsletter-november-2020.md
+++ b/content/posts/newsletter-november-2020.md
@@ -61,7 +61,7 @@ We have started thinking about a job description for the person we hope to bring
 Hiring is always a challenge,
 but we're excited about having growth to be able to think about supporting an additional team member.
 The role we're imagining is an part-time account executive,
-but someone who is interested in growing into a larger full-time business role over time. 
+but someone who is interested in growing into a larger full-time business role over time.
 
 As part of this transition,
 our team member Eric will be scaling back his involvement on advertising from close to 100% of time to 50%.
@@ -82,8 +82,8 @@ The major features in our upcoming roadmap:
 
 * We're still hoping to adapt our ad format to [break out a headline and a call to action](https://github.com/readthedocs/ethical-ad-server/issues/152). This will standardize our ad display, along with making sure that all our advertisers have ads that work across multiple formats.
 * We want to give advertisers a way to change the flight targeting of their advertisements. Changing targeting generally changes the pricing, so this will require the dashboard knowing more about pricing for different targeting options.
-* We're hoping to expand our advertising logic to take into account price when selecting ads. This will allow us to assure maximum revenue for a publisher, but we don't want to always show a single ad on that site, either. 
-* We hope to do a beta test of a sponsorship program with a publisher, which is an extension of the ad network to allow for specific placements on high-value publishers. 
+* We're hoping to expand our advertising logic to take into account price when selecting ads. This will allow us to assure maximum revenue for a publisher, but we don't want to always show a single ad on that site, either.
+* We hope to do a beta test of a sponsorship program with a publisher, which is an extension of the ad network to allow for specific placements on high-value publishers.
 
 Thanks again for being along with us on this journey to build an ethical ad network.
 Please [email us](mailto:ads@ethicalads.io) if you have any ideas or feedback on our product or roadmap,

--- a/content/posts/newsletter-october-2020.md
+++ b/content/posts/newsletter-october-2020.md
@@ -59,11 +59,10 @@ Our upcoming roadmap has a few major tasks on it this month:
 
 * We're planning to adapt our ad format to [break out a headline and a call to action](https://github.com/readthedocs/ethical-ad-server/issues/152). This will standardize our ad display, along with making sure that all our advertisers have ads that work across multiple formats.
 * We're working on a Publisher Prospectus, which is similar to our [advertiser prospectus](https://www.ethicalads.io/prospectus/ethicalads-advertiser-prospectus.pdf) -- a single place to understand what being a publisher looks like.
-* We didn't get to it last month, but we want additional publisher & advertiser landing pages. We hope to build topic-specific pages to share more information for specific audiences on these pages, to go along with our testimonials. 
+* We didn't get to it last month, but we want additional publisher & advertiser landing pages. We hope to build topic-specific pages to share more information for specific audiences on these pages, to go along with our testimonials.
 * We started conversations about trademarking EthicalAds, but haven't applied for it yet. This process will take 4-6 months, but we do want to make sure we've gotten it started.
 * We plan to take our expanded publisher reports and add similar improvements to our advertising reports.
 
 There are many other small tasks we'll continue to work on, along with lots of email :)
 
 Thanks again for following along on our journey, and we're excited to continue to build something we can all be proud of.
-

--- a/content/posts/newsletter-september-2020.md
+++ b/content/posts/newsletter-september-2020.md
@@ -46,7 +46,7 @@ Our current top priority continues to be getting publishers more revenue. As par
 
 We continue to have issues with ad blocking. We have had a good call with the Acceptable Ads team, and are hopeful that we will be added to the approved list in October. That will raise most of our publishers revenues by an estimated 15%, which would be huge.
 
-The other major thing we continue to struggle with is just the amount of work we need to do. Spinning up an entirely new ad network and brand requires a lot of various tasks, and we only have 2 people working on it mostly full-time. We are in discussion in Q4 about doing some kind of hiring, either contract or part-time with the revenue we're seeing from the ad network. We generally try to be conservative in our hiring, so it might get pushed back to next year. 
+The other major thing we continue to struggle with is just the amount of work we need to do. Spinning up an entirely new ad network and brand requires a lot of various tasks, and we only have 2 people working on it mostly full-time. We are in discussion in Q4 about doing some kind of hiring, either contract or part-time with the revenue we're seeing from the ad network. We generally try to be conservative in our hiring, so it might get pushed back to next year.
 
 ## Upcoming features
 

--- a/content/posts/willful-words-and-pretty-pictures.md
+++ b/content/posts/willful-words-and-pretty-pictures.md
@@ -15,28 +15,28 @@ I tried to backpeddle. "No one is personally listening in to your conversations,
 
 One morning in the summer of 1938, my great-grandfather was out for a walk by the river early and he noticed people washing their clothing in the river without bar soap. He decided then and there to tap that market and would go down on his walk every morning with a box full of soap to sell. Selling by the river early in the morning before the factory opened worked incredibly well, until other soap vendors realized the simplistic brilliance of his approach. Soon my great-grandfather was in competition and learned that he had to get creative with drawing attention. My grandmother cautioned me, "The loud, charismatic vendor inevitably sells more soap than the quiet, reserved one." Oy. This is the mindset that has been shaping advertising for the past 100 years; this is how we have arrived at the current state of the internet, almost unbrowsable without an ad-blocker thanks to pop-ups, banner ads, and booby-trapped x's. At least, we were getting somewhere. She definitely understood that our publishers were our river and that we are the soap-sellers, but how do I explain ad-blockers? So I asked my grandma "What if yelling was out-lawed?" "Make yelling illegal?" she repeated incredulously. I told her a little bit about how ad-blockers worked, mildly surprised that I hadn't already set her up with one when I set up her laptop, and explained that EthicalAds gets around ad-blockers *because* our ads are quiet and reserved. "Hmmm..."  After careful consideration, she made up her mind.
 
-"You have your foot in the door, not a seat at the table. Have you considered making your ads ***~beautiful~***?"   
+"You have your foot in the door, not a seat at the table. Have you considered making your ads ***~beautiful~***?"
 
-I'm Ra Cohen: data scientist, people person, and the latest addition to the EthicalAds team. Using pretty pictures, willful words, and data science, I'm on a mission to help people reach their audience and tell their story.    
+I'm Ra Cohen: data scientist, people person, and the latest addition to the EthicalAds team. Using pretty pictures, willful words, and data science, I'm on a mission to help people reach their audience and tell their story.
 
 
 ## Pretty Pictures
 
 As a data scientist, I know just how much impact framing and perspective can have on impressions. A graph zoomed in around all of the action will tell a very different, more turbulent story than the same data presented on a graph with its origin at 0. My design philosophy draws from the Data-Ink ratio principle. The less ink you can use over all, the better, and that ink which you do use should be fundamental to conveying your data. I'm excited to apply my eye for artistry not only in illuminating the beauty of data, but also to illustrate the beauty of advertising. Beauty captures our attention like nothing else, stirring us to action with the promise of a better tomorrow. Is that not also the goal of advertising? To reincarnate Helen of Troy into the image that launches a thousand clicks?
 
-A picture may be worth a thousand words, but context can make it worth a million. 
+A picture may be worth a thousand words, but context can make it worth a million.
 
 
 ## Willful Words
 
-Good writing is the intersection of clarity and purpose. Conveying information and motivating one's audience are best accomplished by the **willful word**, a word mindfully chosen to perform work and left free of clutter. Due to the brevity of advertising, the creatively willful word thrives. The attention of your reader is valuable and respected. We are happy to assist in the creation of your advertising copy upon request. Your time is valuable too, so I endeavor to keep all emails to the point as I assist with advertiser and publisher account management. 
+Good writing is the intersection of clarity and purpose. Conveying information and motivating one's audience are best accomplished by the **willful word**, a word mindfully chosen to perform work and left free of clutter. Due to the brevity of advertising, the creatively willful word thrives. The attention of your reader is valuable and respected. We are happy to assist in the creation of your advertising copy upon request. Your time is valuable too, so I endeavor to keep all emails to the point as I assist with advertiser and publisher account management.
 
-I am also happy to schedule a phone call to discuss your data. 
+I am also happy to schedule a phone call to discuss your data.
 
 
 ## Data Science
 
-Like all science, the first step to data science is to ask a ***question***. Are you a publisher who wants help understanding how our latest updates affected your profits? Or do you want to compare your data over a few ad placement spots in order to maximise your click through rates? Perhaps you're an advertiser who wants to know how changing your targeting will affect your total number of impressions. Send us an email; I breathe data! In school, I took courses in our data science graduate program to fulfil my undergrad computer science requirements. After graduation, I went to work as a research scientsit for two years where I built visualization dashboard prototypes for DARPA. I'm glad to now be working at EthicalAds, shaping the future of advertising for a more respectful, beautiful future. 
+Like all science, the first step to data science is to ask a ***question***. Are you a publisher who wants help understanding how our latest updates affected your profits? Or do you want to compare your data over a few ad placement spots in order to maximise your click through rates? Perhaps you're an advertiser who wants to know how changing your targeting will affect your total number of impressions. Send us an email; I breathe data! In school, I took courses in our data science graduate program to fulfil my undergrad computer science requirements. After graduation, I went to work as a research scientsit for two years where I built visualization dashboard prototypes for DARPA. I'm glad to now be working at EthicalAds, shaping the future of advertising for a more respectful, beautiful future.
 
 
 As always, we are thrilled to have you along with us on our journey to build an ethical ad network.

--- a/ethicalads-theme/templates/ea/learning-hub.html
+++ b/ethicalads-theme/templates/ea/learning-hub.html
@@ -98,13 +98,14 @@
 
               <!-- Heading -->
               <h4 class="font-weight-bold">
-                <a href="/surveillance/">About Surveillance Advertising</a>
+                <a href="#">About Surveillance Advertising</a>
               </h4>
 
               <!-- Text -->
               <p class="text-gray-700 mb-5">
                 What is surveillance advertising and why you should opt-out (and spread the word)
               </p>
+              <p class="text-gray-700"><strong>Coming soon</strong></p>
               
             </div>
           </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pelican-related-posts==1.0.0
 invoke<1.5
 
 # Code formatters and pre-commit checks
-black==19.3b0
-reorder-python-imports<2.0
-pre-commit<2.0
+black==21.5b1
+reorder-python-imports==2.5.0
+pre-commit==2.9.2


### PR DESCRIPTION
These are some changes in preparation for soft-launching the learning hub

- Make pre-commit match requirements
- Make surveillance ads section "coming soon"
- No link to the learning hub
- Fix the image widths


**Note:** This merges into #151, not `main`. The plan is to merge this and *then* merge #151.