### PR TITLE
Remove Cloudflare Analytics

### DIFF
--- a/ethicalads-theme/templates/base.html
+++ b/ethicalads-theme/templates/base.html
@@ -61,9 +61,6 @@
     {% include 'includes/footer.html' %}
 
     <script src="/theme/dist/bundle.js"></script>
-    <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "8ea423c1fa0040949889308446dcde55"}'></script>
-    <!-- End Cloudflare Web Analytics -->
     {% block extrascripts %}{% endblock extrascripts %}
   </body>
 </html>


### PR DESCRIPTION
We are using Plausible now and reasonably happy. I expect we will write a blog about this in the near future.