### PR TITLE
Set URLs on Adv/Pub form success pages

### DIFF
--- a/content/pages/advertiser-success.md
+++ b/content/pages/advertiser-success.md
@@ -1,4 +1,6 @@
 Title: Advertiser Form Submitted
+url: advertisers/contact-success/
+save_as: advertisers/contact-success/index.html
 description: We got your advertisement inquiry and we'll get back to you as soon as we can.
 status: hidden
 

--- a/content/pages/publisher-success.md
+++ b/content/pages/publisher-success.md
@@ -1,4 +1,6 @@
-Title: Form Submitted
+Title: Publisher Form Submitted
+url: publishers/contact-success/
+save_as: publishers/contact-success/index.html
 description: We got your publisher application and we'll get back to you as soon as we can.
 status: hidden
 


### PR DESCRIPTION
The URLs will be `/advertisers/contact-success/` and `/publishers/contact-success/`.