### PR TITLE
Fix links from linkchecker

### DIFF
--- a/content/pages/homepage.md
+++ b/content/pages/homepage.md
@@ -1,4 +1,5 @@
 Title: Privacy-preserving Ad Network for Developers
+url: index.html 
 save_as: index.html
 template: ea/homepage
 status: hidden

--- a/content/pages/homepage.md
+++ b/content/pages/homepage.md
@@ -1,5 +1,4 @@
 Title: Privacy-preserving Ad Network for Developers
-url: index.html 
 save_as: index.html
 template: ea/homepage
 status: hidden

--- a/content/pages/vs-google.md
+++ b/content/pages/vs-google.md
@@ -13,7 +13,7 @@ and we think we're a great alternative for developer-focused sites.
 
 When your user goes to your website, they are assuming they will only be sending data to you. Some users consider it a breach of trust if you were to share that data with other third parties, and it might be a breach of a privacy law to do this without user consent. Google is well-known for it's data collection policies, and they are used to target ads on your website and many other sites around the internet.
 
-When you use EthicalAds, **we never set cookies on your users**, and we don't use any user-specific data to target advertising. This means [you don't need a cookie banner](../content/posts/2021-can-you-remove-cookie-banners.md) when you use our ads, and your users data is not being tracked across the internet.
+When you use EthicalAds, **we never set cookies on your users**, and we don't use any user-specific data to target advertising. This means [you don't need a cookie banner]({filename}../posts/2021-can-you-remove-cookie-banners.md) when you use our ads, and your users data is not being tracked across the internet.
 
 ## Transparency on what ads get shown
 
@@ -31,7 +31,7 @@ With EthicalAds, our code is both simple and open source. You can look at our [e
 
 Google and Facebook account for the vast majority of advertising revenue on the internet. Having all the revenue concentrated in these two companies makes it harder for independent publishers and companies to get started. We think our approach to advertising is worth investing in, and we hope to make it a larger percentage of the way the internet does advertising.
 
-We talk more about the issues with [invasive ad tracking](../content/posts/2021-invasive-ad-targeting-bad-journalism-premium-publishers.md), and how it hurts journalism and anyone creating high-value content on the web. We are hoping to break this vicious cycle by offering a better way to support developer-focused publishers on the internet.
+We talk more about the issues with [invasive ad tracking]({filename}../posts/2021-invasive-ad-targeting-bad-journalism-premium-publishers.md), a{filename}nd how it hurts journalism and anyone creating high-value content on the web. We are hoping to break this vicious cycle by offering a better way to support developer-focused publishers on the internet.
 
 ## Ready to take the next step?
 

--- a/content/pages/vs-google.md
+++ b/content/pages/vs-google.md
@@ -31,7 +31,7 @@ With EthicalAds, our code is both simple and open source. You can look at our [e
 
 Google and Facebook account for the vast majority of advertising revenue on the internet. Having all the revenue concentrated in these two companies makes it harder for independent publishers and companies to get started. We think our approach to advertising is worth investing in, and we hope to make it a larger percentage of the way the internet does advertising.
 
-We talk more about the issues with [invasive ad tracking]({filename}../posts/2021-invasive-ad-targeting-bad-journalism-premium-publishers.md), a{filename}nd how it hurts journalism and anyone creating high-value content on the web. We are hoping to break this vicious cycle by offering a better way to support developer-focused publishers on the internet.
+We talk more about the issues with [invasive ad tracking]({filename}../posts/2021-invasive-ad-targeting-bad-journalism-premium-publishers.md), and how it hurts journalism and anyone creating high-value content on the web. We are hoping to break this vicious cycle by offering a better way to support developer-focused publishers on the internet.
 
 ## Ready to take the next step?
 

--- a/content/posts/newsletter-december-2021.md
+++ b/content/posts/newsletter-december-2021.md
@@ -13,7 +13,7 @@ Happy New Year! December was a shorter month for us at EthicalAds so this update
 These are the major features we released in the last month:
 
 * Debuted the beta for our [sponsorship platform](https://www.ethicalads.io/sponsorship-platform/).
-* Released our [advertising prospectus](https//www.ethicalads.io/prospectus/ethicalads-advertiser-prospectus.pdf) for 2022.
+* Released our [advertising prospectus](https://www.ethicalads.io/prospectus/ethicalads-advertiser-prospectus.pdf) for 2022.
 
 You can always see our latest server updates in our [ethical-ad-server changelog](https://ethical-ad-server.readthedocs.io/en/latest/developer/changelog.html) and [ethical-ad-client changelog](https://ethical-ad-client.readthedocs.io/en/latest/changelog.html).
 

--- a/ethicalads-theme/templates/article.html
+++ b/ethicalads-theme/templates/article.html
@@ -5,6 +5,12 @@
 {% block title %}{{ article.title|striptags  }} - {{ SITENAME }}{% endblock %}
 
 
+{% block canonical_rel %}
+  <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}" />
+  <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}" />
+{% endblock canonical_rel %}
+
+
 {% block content %}
 <section class="container py-5 mb-10">
   <div class="row justify-content-center">

--- a/ethicalads-theme/templates/base.html
+++ b/ethicalads-theme/templates/base.html
@@ -11,6 +11,7 @@
 
       <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
 
+      {% block canonical_rel %}{% endblock canonical_rel %}
 
       <!-- Feeds -->
       {% if FEED_ALL_ATOM %}

--- a/ethicalads-theme/templates/ea/homepage.html
+++ b/ethicalads-theme/templates/ea/homepage.html
@@ -8,6 +8,9 @@
 {% endblock head %}
 
 
+{% block canonical_rel %}<link rel="canonical" href="{{ SITEURL }}">{% endblock %}
+
+
 {% block content %}
 <section class="position-relative mt-5 mb-10">
 

--- a/ethicalads-theme/templates/includes/metas.html
+++ b/ethicalads-theme/templates/includes/metas.html
@@ -18,11 +18,6 @@
     <meta name="author" content="{{ author }}" />
   {%- endfor -%}
 
-  {%- if article.url -%}
-    <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}" />
-    <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}" />
-  {%- endif -%}
-
   <meta property="og:type" content="article">
   <meta property="og:title" content="{{ article.title|striptags|escape }}" />
   <meta property="twitter:title" content="{{ article.title|striptags|escape }}" />
@@ -39,11 +34,6 @@
   {%- if page.description -%}
     <meta name="description" content="{{ page.description|striptags|escape }}" />
     <meta property="og:description" content="{{ page.description|striptags|escape }}" />
-  {%- endif -%}
-
-  {%- if page.url -%}
-    <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}" />
-    <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}" />
   {%- endif -%}
 
   <meta property="og:type" content="article" />

--- a/ethicalads-theme/templates/page.html
+++ b/ethicalads-theme/templates/page.html
@@ -5,6 +5,12 @@
 {% block title %}{{ page.title|striptags }} - {{ SITENAME }}{%endblock%}
 
 
+{% block canonical_rel %}
+  <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}" />
+  <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}" />
+{% endblock canonical_rel %}
+
+
 {% block content %}
 <section class="container py-5 mb-10">
   <article class="page">


### PR DESCRIPTION
The biggest issue is that we were setting our homepage canonical URL to:
```
<link rel="canonical" href="https://www.ethicalads.io/privacy-preserving-ad-network-for-developers/" />
```
Presumably because of the title of the page?

What I ran was:

```
docker run --rm -it linkchecker/linkchecker https://ethicalads.io
```
