### PR TITLE
Add comparison to other ad networks

### DIFF
--- a/content/pages/vs-carbon-ads.md
+++ b/content/pages/vs-carbon-ads.md
@@ -1,11 +1,11 @@
-Title: How does EthicalAds compare to other developer-focused ad networks?
-url: alternative-to-developer-ad-networks
-save_as: alternative-to-developer-ad-networks/index.html
+Title: What Makes EthicalAds a Great Carbon Ads Alternative
+url: alternative-to-carbon-ads
+save_as: alternative-to-carbon-ads/index.html
 description: How are we different? Privacy guarantees, open source code, and community-focus.
 
 We know that we are competing with a few other ad networks that focus on developers.
 This page talks a bit more about how we're different,
-and why you might want to choose us instead of Carbon Ads or Stack Overflow.
+and why you might want to choose us instead of Carbon Ads.
 
 [TOC]
 

--- a/content/pages/vs-carbon-ads.md
+++ b/content/pages/vs-carbon-ads.md
@@ -1,4 +1,4 @@
-Title: What Makes EthicalAds a Great Carbon Ads Alternative
+Title: What Makes EthicalAds a Great Carbon Ads Alternative for Your Site
 url: alternative-to-carbon-ads
 save_as: alternative-to-carbon-ads/index.html
 description: How are we different? Privacy guarantees, open source code, and community-focus.
@@ -13,12 +13,13 @@ and why you might want to choose us instead of Carbon Ads.
 
 When your user goes to your website, they are assuming they will only be sending data to you. Some users consider it a breach of trust if you were to share that data with other third parties, and it might be a breach of a privacy law to do this without user consent.
 
-These networks will often set cookies on your browser session, as well as load scripts hosted by Google into a publishers web page. You can see a screenshot of Carbon Ads loading a Google script here:
+These networks will often set cookies on your browser session, as well as load scripts hosted by Google into a publishers web page. You can see a screenshot of Carbon Ads loading a Google tracking pixel here:
 
 <div class="m-5 postimage">
   <a href="{static}../images/posts/2021-third-party-resources.png">
   <img class="w-50 rounded mx-auto d-block"  src="{static}../images/posts/2021-third-party-resources.png" alt="An ad network loading third-party resources">
   </a>
+  <p><small>Carbon sometimes loads third-party resources from Google or other trackers</small></p>
 </div>
 
 > Removing Our 3rd Party Ad-Serving Cookie from Your Browser

--- a/content/pages/vs-dev-ad-networks.md
+++ b/content/pages/vs-dev-ad-networks.md
@@ -1,7 +1,7 @@
 Title: How does EthicalAds compare to other developer-focused ad networks?
 url: alternative-to-developer-ad-networks
 save_as: alternative-to-developer-ad-networks/index.html
-description: How are we different? Privacy gaurantees, open source code, and community-focus.
+description: How are we different? Privacy guarantees, open source code, and community-focus.
 
 We know that we are competing with a few other ad networks that focus on developers.
 This page talks a bit more about how we're different,
@@ -44,7 +44,7 @@ as well as by giving them money as publishers.
 
 The code behind other networks is proprietary and incredibly complex. This is because there is a large amount of time being spent trying to figure out exactly who you are and how to target you with an ad.
 
-With EthicalAds, our code is both simple and open source. You can look at our [ethical ad server](https://github.com/readthedocs/ethical-ad-server/) and [ethical ad client](https://github.com/readthedocs/ethical-ad-client/) on GitHub. **You can read the exact logic we use to select that ads that show on your website**, because we don't need complex tracking logic.
+With EthicalAds, our code is both simple and open source. You can look at our [ethical ad server](https://github.com/readthedocs/ethical-ad-server/) and [ethical ad client](https://github.com/readthedocs/ethical-ad-client/) on GitHub. You can read the exact logic we use to select that ads that show on your website, because we don't need complex tracking logic.
 
 ## **Join today**: Ready to take the next step?
 

--- a/content/pages/vs-dev-ad-networks.md
+++ b/content/pages/vs-dev-ad-networks.md
@@ -1,0 +1,60 @@
+Title: How does EthicalAds compare to other developer-focused ad networks?
+url: alternative-to-developer-ad-networks
+save_as: alternative-to-developer-ad-networks/index.html
+description: How are we different? Privacy gaurantees, open source code, and community-focus.
+
+We know that we are competing with a few other ad networks that focus on developers.
+This page talks a bit more about how we're different,
+and why you might want to choose us instead of Carbon Ads or Stack Overflow.
+
+[TOC]
+
+## **Privacy**: We never set a cookie on your site, or load third-party scripts.
+
+When your user goes to your website, they are assuming they will only be sending data to you. Some users consider it a breach of trust if you were to share that data with other third parties, and it might be a breach of a privacy law to do this without user consent.
+
+These networks will often set cookies on your browser session, as well as load scripts hosted by Google into a publishers web page. You can see a screenshot of Carbon Ads loading a Google script here:
+
+<div class="m-5 postimage">
+  <a href="{static}../images/posts/2021-third-party-resources.png">
+  <img class="w-50 rounded mx-auto d-block"  src="{static}../images/posts/2021-third-party-resources.png" alt="An ad network loading third-party resources">
+  </a>
+</div>
+
+> Removing Our 3rd Party Ad-Serving Cookie from Your Browser
+> 
+> &mdash; Carbon Ads (BuySellAds) [Privacy Policy](https://www.buysellads.com/about/privacy)
+
+
+EthicalAds will never set cookies on your users, and we don't use any user-specific data to target advertising. This means [you don't need a cookie banner]({filename}../posts/2021-can-you-remove-cookie-banners.md), we are GDPR-compliant, and your users data is not being tracked across the internet.
+
+
+## **Community**: We give back with Community Ads
+
+Our long history in the open source community helps guide the actions that we take as an organization.
+We appreciate that we have the ability to give back to other projects,
+so we offer [Community Ads]({filename}/pages/community-ads.md) for projects to show community-focused ads for free.
+
+We have run this program since we launched ads on Read the Docs,
+because we love being able to support other projects. 
+This program allows EthicalAds to help give back to other projects in free advertising,
+as well as by giving them money as publishers.
+
+## **Open Source**: Our code is open source, and easy to read
+
+The code behind other networks is proprietary and incredibly complex. This is because there is a large amount of time being spent trying to figure out exactly who you are and how to target you with an ad.
+
+With EthicalAds, our code is both simple and open source. You can look at our [ethical ad server](https://github.com/readthedocs/ethical-ad-server/) and [ethical ad client](https://github.com/readthedocs/ethical-ad-client/) on GitHub. **You can read the exact logic we use to select that ads that show on your website**, because we don't need complex tracking logic.
+
+## **Join today**: Ready to take the next step?
+
+Improving the advertising ecosystem is [why we are building our company]({filename}/pages/vision.md).
+We hope that you'll join us.
+
+We believe the open source community should show the way forward,
+since we have a deep understanding of how privacy issues impact the internet.
+We have space for additional publishers,
+and look forward to building something meaningful with you:
+
+* Become a [publisher]({filename}/pages/publishers.md) today
+* Follow our journey in our [newsletter](https://ethicalads.us17.list-manage.com/subscribe/post?u=ca5e74de3ea2867d373058271&id=5746f18bb8)

--- a/content/posts/2021-do-the-ads-on-your-site-respect-privacy.md
+++ b/content/posts/2021-do-the-ads-on-your-site-respect-privacy.md
@@ -35,7 +35,9 @@ they can cookie and track the users on your site across the web
 (and then [show ads to your users more cheaply elsewhere]({filename}2021-invasive-ad-targeting-bad-journalism-premium-publishers.md)).
 
 <div class="postimage">
+  <a href="{static}../images/posts/2021-third-party-resources.png">
   <img class="w-100" src="{static}../images/posts/2021-third-party-resources.png" alt="An ad network loading third-party resources">
+  </a>
   <p>An ad network loading third-party resources.</p>
 </div>
 

--- a/ethicalads-theme/templates/includes/footer.html
+++ b/ethicalads-theme/templates/includes/footer.html
@@ -101,6 +101,9 @@
           <li class="mb-3">
             <a href="/alternative-to-google-ads/" class="text-reset">Google Ads Comparison</a>
           </li>
+          <li class="mb-3">
+            <a href="/alternative-to-developer-ad-networks/" class="text-reset">Carbon Ads Comparison</a>
+          </li>
         </ul>
 
       </div>

--- a/ethicalads-theme/templates/includes/footer.html
+++ b/ethicalads-theme/templates/includes/footer.html
@@ -102,7 +102,7 @@
             <a href="/alternative-to-google-ads/" class="text-reset">Google Ads Comparison</a>
           </li>
           <li class="mb-3">
-            <a href="/alternative-to-developer-ad-networks/" class="text-reset">Carbon Ads Comparison</a>
+            <a href="/alternative-to-carbon-ads/" class="text-reset">Carbon Ads Comparison</a>
           </li>
         </ul>
 


### PR DESCRIPTION
The goal here is to show how we're different..
I wasn't sure how direct we wanted to be,
so I made the link and some copy focus mostly on Carbon.
I did include Stack Overflow as well,
since I think they are our other major competitor here.

I considered having both `Comparison to Carbon/Stack Overflow` in the footer linking to the same page,
but wasn't sure the best approach?