### PR TITLE
Clean up copy on team page & rejigger learning hub

### DIFF
--- a/ethicalads-theme/templates/ea/about.html
+++ b/ethicalads-theme/templates/ea/about.html
@@ -20,18 +20,33 @@
 
         <!-- Image -->
         <div class="form-row">
-          <div class="col-12 col-md-6 mb-5 mb-md-0 text-center">
 
-            <img src="/images/pages/ads-offsite-2021.jpg" class="w-75 img-fluid rounded shadow-lg" alt="The EthicalAds team at our 2021 offsite">
+{#           <div class="col-12 col-md-6 mb-5 mb-md-0 text-center">
+
+            <img src="/images/pages/offsite-2019.jpg" class="w-75 img-fluid rounded shadow-lg" alt="The team at our 2018 offsite">
 
           </div>
+ #}
+
+          <div class="col-12 col-md-6">
+
+            <h2>Fully-owned by our founders</h2>
+
+            <p>
+              We have a strong mission, and in order to succeed we need to be able to focus fully on it.
+              This means we haven't raised any outside funding,
+              and are fully aligned with our network of publishers and advertisers.
+            </p>
+            <p>Read more about our <a href="/advertising-vision/">vision for ethical advertising</a>.</p>
+          </div>
+
           <div class="col-12 col-md-6">
 
             <h2>Small Team. Big Impact.</h2>
 
-            <p>EthicalAds was built to sustain open source development of Read the Docs, an open source documentation platform. Advertising was the natural model because it scaled up well as our platform grew. However, we wanted to do ads right without tracking users or having security issues with third-party scripts. Since no existing ad networks would partner with us on privacy-respecting ads, we built our own.</p>
-
-            <p>Read more about our <a href="https://docs.readthedocs.io/en/latest/team.html#development-team">team</a> and our <a href="/advertising-vision/">vision for ethical advertising</a>.</p>
+            <p>EthicalAds was built to sustain development of Read the Docs, an open source documentation platform. Advertising was the natural model because it scaled up well as our platform grew. However, we wanted to do ads right without tracking users or having security issues with third-party scripts.
+            </p>
+            <p>Since no existing ad networks would partner with us on privacy-respecting ads, we built our own.</p>
 
           </div>
         </div>
@@ -40,7 +55,6 @@
     </div> <!-- / .row -->
   </div> <!-- / .container -->
 </section>
-
 
 <!-- People -->
 <section class="container py-5">
@@ -61,13 +75,6 @@
       </div>
       <h3 class="text-center font-weight-bold">David Fischer</h3>
       <p>David joined Read the Docs back in 2017 to work on security, privacy, and to build EthicalAds. He saw the importance of ethical advertising and joined the team to help take the approach from a single site to a larger network that supported the open source ecosystem. Previously David worked on security at Qualcomm and Amazon before being director of technology at TapHunter.</p>
-    </div>
-    <div class="col-12 col-md-6 mb-5 px-md-10">
-      <div class="text-center mb-3">
-        <img src="/images/pages/team-ra.jpg" class="w-50 rounded-circle" alt="Ra Cohen" />
-      </div>
-      <h3 class="text-center font-weight-bold">Ra Cohen</h3>
-      <p>Ra orginally joined EthicalAds in 2021 as a data scientist and designated people person. They're excited to assist with account management, bespoke data visualizations, and in bringing machine learning to privacy preserving advertising. Ra previously worked as an intern for Google and then as a research scientist at Perspecta Labs, a descendent of Bell Labs.</p>
     </div>
   </div>
 </section>

--- a/ethicalads-theme/templates/ea/learning-hub.html
+++ b/ethicalads-theme/templates/ea/learning-hub.html
@@ -38,32 +38,56 @@
     <div class="container my-10">
 
       <div class="card-deck">
-          
-        <!-- Card -->
-        <div class="card card-border border-primary shadow-lg mb-6 mb-md-8 lift lift-lg">
-          
+
+       <!-- Card -->
+        <div class="card card-border border-danger shadow-lg mb-6 mb-md-8 mb-lg-8 lift lift-lg">
           <div class="card-body text-center">
 
             <!-- Icon -->
-            <div class="icon-circle bg-primary text-white mb-5">
-              <span class="fe fe-eye"></span>
+            <div class="icon-circle bg-danger text-white mb-5">
+              <i class="fe fe-target"></i>
             </div>
 
             <!-- Heading -->
             <h4 class="font-weight-bold">
-              <a href="/advertising-vision/">Our Ad Vision</a>
+              <a href="/advertiser-guide/">Advertiser's Guide</a>
             </h4>
 
             <!-- Text -->
             <p class="text-gray-700 mb-5">
-              What is ethical advertising and what you can do to support content publishers without having creepy tracking
+              This guide contains helpful tips and tricks to help you optimize your ad campaign for our developer audience
             </p>
-            
+
           </div>
         </div>
+
+
+        <!-- Card -->
+        <div class="card card-border border-primary-desat shadow-lg mb-6 mb-md-8 mb-lg-8 lift lift-lg">
+          <div class="card-body text-center">
+
+            <!-- Icon -->
+            <div class="icon-circle bg-primary-desat text-white mb-5">
+              <i class="fe fe-layout"></i>
+            </div>
+
+            <!-- Heading -->
+            <h4 class="font-weight-bold">
+              <a href="/publisher-guide/">Publisher's Guide</a>
+            </h4>
+
+            <!-- Text -->
+            <p class="text-gray-700 mb-5">
+              Learn more about how to ensure ads are relevant and well-positioned on your site, helping you earn more money from your ad space
+            </p>
+
+          </div>
+        </div>
+
+
         
         <!-- Card -->
-        <div class="card card-border border-success shadow-lg mb-6 mb-md-8 lift lift-lg">
+        <div class="card card-border border-success shadow-lg mb-6 mb-md-8 mb-lg-8 lift lift-lg">
           <div class="card-body text-center">
 
             <!-- Icon -->
@@ -78,13 +102,39 @@
 
             <!-- Text -->
             <p class="text-gray-700 mb-5">
-              Details and description about the EthicalAds audience breakdown
+              Details and description about the EthicalAds audience, including geographic and topic breakdowns for our entire network
             </p>
             
           </div>
         </div>
 
+
+      </div><!-- /.card-deck -->
+      <div class="card-deck">
         
+         <!-- Card -->
+        <div class="card card-border border-primary shadow-lg mb-6 mb-md-8 lift lift-lg">
+
+          <div class="card-body text-center">
+
+            <!-- Icon -->
+            <div class="icon-circle bg-primary text-white mb-5">
+              <span class="fe fe-eye"></span>
+            </div>
+
+            <!-- Heading -->
+            <h4 class="font-weight-bold">
+              <a href="/advertising-vision/">Our Advertising Vision</a>
+            </h4>
+
+            <!-- Text -->
+            <p class="text-gray-700 mb-5">
+              What is ethical advertising and what you can do to support content publishers in the advertising ecosystem
+            </p>
+            
+          </div>
+        </div>
+
         <!-- Card -->
         <div class="card card-border border-warning shadow-lg mb-6 mb-md-8 lift lift-lg">
           <div class="card-body text-center">
@@ -101,63 +151,14 @@
 
             <!-- Text -->
             <p class="text-gray-700 mb-5">
-              What is surveillance advertising and why you should opt-out (and spread the word)
+              What is surveillance advertising and why you should opt-out
             </p>
-            
+
           </div>
         </div>
-
-      </div><!-- /.card-deck -->
-      <div class="card-deck">
         
         <!-- Card -->
-        <div class="card card-border border-danger shadow-lg mb-6 mb-md-8 mb-lg-0 lift lift-lg">
-          <div class="card-body text-center">
-
-            <!-- Icon -->
-            <div class="icon-circle bg-danger text-white mb-5">
-              <i class="fe fe-target"></i>
-            </div>
-
-            <!-- Heading -->
-            <h4 class="font-weight-bold">
-              <a href="/advertiser-guide/">Advertiser's Guide</a>
-            </h4>
-
-            <!-- Text -->
-            <p class="text-gray-700 mb-5">
-              This guide contains helpful tips and tricks to get the most out of your privacy-respecting ads.
-            </p>
-            
-          </div>
-        </div>
-
-        
-        <!-- Card -->
-        <div class="card card-border border-primary-desat shadow-lg mb-6 mb-md-0 lift lift-lg">
-          <div class="card-body text-center">
-
-            <!-- Icon -->
-            <div class="icon-circle bg-primary-desat text-white mb-5">
-              <i class="fe fe-layout"></i>
-            </div>
-
-            <!-- Heading -->
-            <h4 class="font-weight-bold">
-              <a href="/publisher-guide/">Publisher's Guide</a>
-            </h4>
-
-            <!-- Text -->
-            <p class="text-gray-700 mb-5">
-              Learn more about how to make sure ads are relevant and well-positioned on your site which will help you earn more money from your ad space.
-            </p>
-            
-          </div>
-        </div>
-
-        
-        <!-- Card -->
-        <div class="card card-border border-dark shadow-lg lift lift-lg">
+        <div class="card card-border border-dark shadow-lg mb-md-8 lift lift-lg">
           <div class="card-body text-center">
 
             <!-- Icon -->
@@ -172,7 +173,7 @@
 
             <!-- Text -->
             <p class="text-gray-700 mb-5">
-              Learn more about EthicalAds and why we built an ad network without tracking users.
+              Learn more about our team and the company behind our ethical ad network
             </p>
             
           </div>


### PR DESCRIPTION
I swapped the ordering of the learning hub to highlight our publisher & advertiser guides,
which seem like the most important currently.

Also removed Ra from the team page,
and added a boostrapping section about the company.