### PR TITLE
Remove RTD branding from the EA site

### DIFF
--- a/content/pages/advertising-faq.md
+++ b/content/pages/advertising-faq.md
@@ -179,4 +179,4 @@ We thought you'd never ask. Simply fill out our [advertising
 information form]({filename}advertisers.md#inbound-form).
 A member of our team will contact you with a detailed prospectus and
 will walk you through the process of getting started advertising on
-Read the Docs.
+EthicalAds.

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -6,5 +6,5 @@ contact_footer_subject: Contact EthicalAds
 contact_footer_subheadline: Some one from our team will get back to you as soon as possible.
 contact_footer_why: Tell us a bit about yourself and your interest in EthicalAds
 
-Thanks for your interest in EthicalAds & Read the Docs.
+Thanks for your interest in EthicalAds.
 Want to speak with someone at EthicalAds? Please get in touch [below](#inbound-form).

--- a/content/pages/press.md
+++ b/content/pages/press.md
@@ -6,7 +6,7 @@ contact_footer_subject: Press Inquiry
 contact_footer_subheadline: We're thrilled you're interested in what we're building.
 contact_footer_why: Tell us a bit about who you are and what you're writing about
 
-Thanks for your interest in writing about EthicalAds & Read the Docs.
+Thanks for your interest in writing about EthicalAds.
 
 ### Quick style guide
 

--- a/ethicalads-theme/templates/ea/advertisers-hiring.html
+++ b/ethicalads-theme/templates/ea/advertisers-hiring.html
@@ -126,7 +126,7 @@
 
           <!-- Text -->
           <p class="mb-5 mb-md-7">
-            “Read the Docs and EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers.”
+            “EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers.”
           </p>
 
           <!-- Footer -->

--- a/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
+++ b/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
@@ -19,7 +19,7 @@
       <div class="card-body text-center">
 
         <!-- Text -->
-        <p class="text-gray-700 mb-5 small">"Read the Docs and EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers."</p>
+        <p class="text-gray-700 mb-5 small">"EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers."</p>
 
         <!-- Photo -->
         <div class="img-fluid mb-5 w-25 mx-auto">

--- a/ethicalads-theme/templates/ea/testimonials/pallets.html
+++ b/ethicalads-theme/templates/ea/testimonials/pallets.html
@@ -118,7 +118,7 @@
 
         <!-- Text -->
         <p class="mb-5 mb-md-7">
-          “We wanted the revenue from ads while respecting our users' privacy and attention. Read the Docs and EthicalAds were the perfect fit, delivering high quality, privacy, and a wonderful team.”
+          “We wanted the revenue from ads while respecting our users' privacy and attention. EthicalAds was the perfect fit, delivering high quality, privacy, and a wonderful team.”
         </p>
 
         <!-- Footer -->

--- a/ethicalads-theme/templates/ea/testimonials/tidelift.html
+++ b/ethicalads-theme/templates/ea/testimonials/tidelift.html
@@ -88,7 +88,7 @@
 
         <!-- Text -->
         <p class="mb-5 mb-md-7">
-          “Advertising with EthicalAds and Read the Docs has been a great way to reach developers and users of open source. The CPL is much lower than other digital advertisement offers, and the audience is tailored to our mission.”
+          “Advertising with EthicalAds has been a great way to reach developers and users of open source. The CPL is much lower than other digital advertisement offers, and the audience is tailored to our mission.”
         </p>
 
         <!-- Footer -->

--- a/ethicalads-theme/templates/ea/testimonials/triplebyte.html
+++ b/ethicalads-theme/templates/ea/testimonials/triplebyte.html
@@ -88,7 +88,7 @@
 
         <!-- Text -->
         <p class="mb-5 mb-md-7">
-          “Read the Docs and EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers.”
+          “EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers.”
         </p>
 
         <!-- Footer -->


### PR DESCRIPTION
I think this cleans up the brand,
and we can stand alone with it at this point in our copy I think.