### PR TITLE
Minor lint fixes around canonical

### DIFF
--- a/content/pages/homepage.md
+++ b/content/pages/homepage.md
@@ -1,5 +1,6 @@
 Title: Developer Ad Network with privacy built in
 save_as: index.html
 template: ea/homepage
+url:
 status: hidden
 description: EthicalAds is a an ad network for developers that takes privacy seriously. We use powerful content targeting to match ads with the right audience without any user tracking.

--- a/ethicalads-theme/templates/ea/homepage.html
+++ b/ethicalads-theme/templates/ea/homepage.html
@@ -8,9 +8,6 @@
 {% endblock head %}
 
 
-{% block canonical_rel %}<link rel="canonical" href="{{ SITEURL }}">{% endblock %}
-
-
 {% block content %}
 <section class="position-relative mt-5 mb-10">
 

--- a/ethicalads-theme/templates/page.html
+++ b/ethicalads-theme/templates/page.html
@@ -6,8 +6,10 @@
 
 
 {% block canonical_rel %}
-  <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}" />
-  <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}" />
+  {% if SITEURL %}
+    <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}" />
+    <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}" />
+  {% endif %}
 {% endblock canonical_rel %}
 
 


### PR DESCRIPTION
- Only add a canonical URL if SITEURL is set (it is only in production after running `inv preview`)
- This makes the linter happy even when building in dev