### PR TITLE
Add Full publisher list

### DIFF
--- a/content/pages/advertising-faq.md
+++ b/content/pages/advertising-faq.md
@@ -176,6 +176,12 @@ is customizable based on their requirements, but we always ensure
 a valuable placement.
 
 
+## What are the top publishers on your network?
+
+Sure, we have a [curated list of some of the largest publishers](/publishers/list/)
+for each of main topics.
+
+
 ## What type of ads are acceptable?
 
 We want ads that are of interest to our audience of millions of

--- a/content/pages/publisher-list.md
+++ b/content/pages/publisher-list.md
@@ -1,0 +1,341 @@
+Title: Publisher list 
+url: publishers/list/
+save_as: publishers/list/index.html
+description: A curated selection of our publishers that exemplify each of our topics.
+
+
+
+<section class="container py-10">
+  <div class="row">
+    <div class="col mb-3">
+      <h2 class="text-center font-weight-bold mb-8">Selected frontend and JS publishers</h2>
+    </div>
+  </div>
+
+  <div class="card-deck">
+
+    <!-- Publisher 1 -->
+    <div class="card card-border shadow-light-lg border-top border-secondary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/bootstraptable.png" alt="Bootstrap Table">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://bootstrap-table.com/">Bootstrap Table</a></p>
+
+          <span class="badge badge-secondary-soft">Module</span>
+
+      </div>
+    </div>
+
+
+
+    <!-- Publisher 2 -->
+    <div class="card card-border shadow-light-lg border-top border-info">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/jsbin.svg" alt="JSBin">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://jsbin.com/">JSBin</a></p>
+
+          <span class="badge badge-info-soft">Project</span>
+
+      </div>
+    </div>
+
+
+    <!-- Publisher 3 -->
+    <div class="card card-border shadow-light-lg border-top border-secondary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/datatablesnet.png" alt="DataTables">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://datatables.net/">DataTables</a></p>
+
+          <span class="badge badge-secondary-soft">Module</span>
+
+      </div>
+    </div>
+
+  </div><!-- /.card-deck -->
+
+</section>
+
+<section class="container py-10">
+  <div class="row">
+    <div class="col mb-3">
+      <h2 class="text-center font-weight-bold mb-8">Selected backend and full stack publishers</h2>
+    </div>
+  </div>
+
+  <div class="card-deck">
+
+    <!-- Publisher 1 -->
+    <div class="card card-border shadow-light-lg border-top border-info">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/django-packages.png" alt="Django Packages">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://djangopackages.org/">Django Packages</a></p>
+
+          <span class="badge badge-info-soft">Project</span>
+
+      </div>
+    </div>
+
+
+
+    <!-- Publisher 2 -->
+    <div class="card card-border shadow-light-lg border-top border-secondary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/flask.png" alt="Flask">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://flask.palletsprojects.com/en/latest/">Flask Microframework</a></p>
+
+          <span class="badge badge-secondary-soft">Module</span>
+
+      </div>
+    </div>
+
+
+    <!-- Publisher 3 -->
+    <div class="card card-border shadow-light-lg border-top border-success">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/celeryproject.png" alt="Celery">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://docs.celeryq.dev/en/stable/">Celery Distributed Tasks</a></p>
+
+          <span class="badge badge-success-soft">Docs</span>
+
+      </div>
+    </div>
+
+  </div><!-- /.card-deck -->
+
+</section>
+
+<section class="container py-10">
+  <div class="row">
+    <div class="col mb-3">
+      <h2 class="text-center font-weight-bold mb-8">Selected data science and machine learning publishers</h2>
+    </div>
+  </div>
+
+  <div class="card-deck">
+
+    <!-- Publisher 1 -->
+    <div class="card card-border shadow-light-lg border-top border-success">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/textacy.png" alt="TextaCy">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://textacy.readthedocs.io">TextaCy</a></p>
+
+          <span class="badge badge-success-soft">Docs</span>
+
+      </div>
+    </div>
+
+
+
+    <!-- Publisher 2 -->
+    <div class="card card-border shadow-light-lg border-top border-info">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/jupyter.png" alt="Jupyter">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://docs.jupyter.org/">Jupyter Project</a></p>
+
+          <span class="badge badge-info-soft">Project</span>
+
+      </div>
+    </div>
+
+
+    <!-- Publisher 3 -->
+    <div class="card card-border shadow-light-lg border-top border-success">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/numba.png" alt="Numba">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://numba.readthedocs.io/">Numba</a></p>
+
+          <span class="badge badge-success-soft">Docs</span>
+
+      </div>
+    </div>
+
+  </div><!-- /.card-deck -->
+
+</section>
+
+<section class="container py-10">
+  <div class="row">
+    <div class="col mb-3">
+      <h2 class="text-center font-weight-bold mb-8">Selected DevOps publishers</h2>
+    </div>
+  </div>
+
+  <div class="card-deck">
+
+    <!-- Publisher 1 -->
+    <div class="card card-border shadow-light-lg border-top border-secondary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/python-docker.png" alt="Docker SDK for Python">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://docker-py.readthedocs.io/">Docker SDK for Python</a></p>
+
+          <span class="badge badge-secondary-soft">Module</span>
+
+      </div>
+    </div>
+
+
+
+    <!-- Publisher 2 -->
+    <div class="card card-border shadow-light-lg border-top border-primary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/linuxmint.png" alt="Linux Mint User Guide">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://linuxmint-user-guide.readthedocs.io/">Linux Mint User Guide</a></p>
+
+          <span class="badge badge-primary-soft">Articles</span>
+
+      </div>
+    </div>
+
+
+    <!-- Publisher 3 -->
+    <div class="card card-border shadow-light-lg border-top border-info">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/dailydev.png" alt="daily.dev">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://daily.dev">daily.dev</a></p>
+
+          <span class="badge badge-info-soft">Project</span>
+
+      </div>
+    </div>
+
+  </div><!-- /.card-deck -->
+
+</section>
+
+<section class="container py-10">
+  <div class="row">
+    <div class="col mb-3">
+      <h2 class="text-center font-weight-bold mb-8">Selected security and privacy publishers</h2>
+    </div>
+  </div>
+
+  <div class="card-deck">
+
+    <!-- Publisher 1 -->
+    <div class="card card-border shadow-light-lg border-top border-success">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/scapy.png" alt="Scapy">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://scapy.readthedocs.io/">Scapy</a></p>
+
+          <span class="badge badge-success-soft">Docs</span>
+
+      </div>
+    </div>
+
+
+
+    <!-- Publisher 2 -->
+    <div class="card card-border shadow-light-lg border-top border-primary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/oauthnet.png" alt="OAuth.net">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://oauth.net/">OAuth.net</a></p>
+
+          <span class="badge badge-primary-soft">Articles</span>
+
+      </div>
+    </div>
+
+
+    <!-- Publisher 3 -->
+    <div class="card card-border shadow-light-lg border-top border-secondary">
+      <div class="card-body text-center">
+
+        <!-- Image -->
+        <div class="img-fluid mb-5 w-50 mx-auto">
+          <img src="/theme/img/topics-publishers/itsdangerous.png" alt="It's Dangerous Python module">
+        </div>
+
+        <!-- Text -->
+        <p class="text-gray-700 mb-2 small"><a href="https://itsdangerous.palletsprojects.com/">It's Dangerous</a></p>
+
+          <span class="badge badge-secondary-soft">Module</span>
+
+      </div>
+    </div>
+
+  </div><!-- /.card-deck -->
+
+</section>

--- a/content/pages/publisher-list.md
+++ b/content/pages/publisher-list.md
@@ -4,6 +4,10 @@ save_as: publishers/list/index.html
 description: A curated selection of our publishers that exemplify each of our topics.
 
 
+### A curated selection of our publishers that exemplify each of our topics.
+
+This page is shows a listing of our publishers in each of our various topics.
+It's a great way to get a sense of who's on our network.
 
 <section class="container py-10">
   <div class="row">
@@ -339,3 +343,8 @@ description: A curated selection of our publishers that exemplify each of our to
   </div><!-- /.card-deck -->
 
 </section>
+
+## Ready to join the network?
+
+* Become a [publisher]({filename}/pages/publishers.md) today
+* Become an [advertiser]({filename}/pages/advertisers.md) today

--- a/content/pages/topics/frontend-web.md
+++ b/content/pages/topics/frontend-web.md
@@ -4,7 +4,6 @@ url: advertisers/topics/frontend-web/
 save_as: advertisers/topics/frontend-web/index.html
 description: EthicalAds is a great solution for marketing to Frontend and JavaScript developers.
 template: ea/topics/topics-generic
-
 inbound_form_frontend: True
 topics_image_path: /theme/img/frontend-web.jpg
 topics_image_alt: Frontend web development

--- a/content/pages/topics/frontend-web.md
+++ b/content/pages/topics/frontend-web.md
@@ -4,6 +4,7 @@ url: advertisers/topics/frontend-web/
 save_as: advertisers/topics/frontend-web/index.html
 description: EthicalAds is a great solution for marketing to Frontend and JavaScript developers.
 template: ea/topics/topics-generic
+
 inbound_form_frontend: True
 topics_image_path: /theme/img/frontend-web.jpg
 topics_image_alt: Frontend web development

--- a/ethicalads-theme/templates/ea/advertisers.html
+++ b/ethicalads-theme/templates/ea/advertisers.html
@@ -207,7 +207,7 @@
     <div class="row mb-5">
       <div class="col-12 col-md-6 mb-3">
         <h4 class="font-weight-bold" id="faq-get-started">What are the top sites on the network?</h4>
-        <p>Our <a href="#audiences">audiences</a> section has some of the top publishers on our network for data science, DevOps, and our other main topics.</p>
+        <p>Check out our <a href="/publishers/list/">publisher list</a> which has some of the top publishers on our network for data science, DevOps, and our other main topics.</p>
       </div>
       <div class="col-md-6">
         <h4 class="font-weight-bold" id="faq-how-much">Is the platform self-serve?</h4>


### PR DESCRIPTION
This is just copying the HTML from each of the existing pages,
because I couldn't find a nice way to pull that data dynamically.
If we have a good way do to this,
or store this data centrally in a way we can reuse that would be amazing.

Thinking something like:

```
data:
  publishers:
    frontend:
      - image:
        link:
      - image:
        link
...
``` 

![127 0 0 1_8000_publishers_list_](https://user-images.githubusercontent.com/25510/211647485-ebdafe16-fa17-4ee4-9659-dae914ec2a7c.png)
