### PR TITLE
Update post for privacy week 2023

### DIFF
--- a/content/posts/2023-data-privacy-week.md
+++ b/content/posts/2023-data-privacy-week.md
@@ -43,7 +43,7 @@ but it even allows you to allow list certain YouTube and Twitch channels to run 
 so you can support your favorite creators.
 The creators of AdBlockPlus have gone on to form the [Acceptable Ads Committee](https://acceptableads.com/about/)
 who's [Acceptable Ads Standard](https://acceptableads.com/standard/) we follow
-as EthicalAds believes in their mission of creating a sustainable and fair compromise between user preference and creator monetization.
+as EthicalAds believes in their mission of creating a sustainable compromise between user preference and creator monetization.
 
 However, by default AdBlockPlus permits "Acceptable Ads" that [use third-party tracking](https://help.getadblock.com/support/solutions/articles/6000224547-about-acceptable-ads-and-third-party-tracking/).
 The standard for an unacceptable ad is largely focused on how annoying an ad is to the user experience

--- a/content/posts/2023-data-privacy-week.md
+++ b/content/posts/2023-data-privacy-week.md
@@ -1,55 +1,55 @@
-Title: Data Privacy Day 2022 - 6+ Privacy-first Alternatives
-Date: January 28, 2022
-description: In celebration of data privacy day, we discuss some of the privacy-first products that we actually use.
+Title: Data Privacy Week 2023 - Privacy-first Alternatives
+Date: January 23, 2023
+description: In celebration of data privacy week, we discuss some of the privacy-first alternatives to the big search engines, browsers, and analytics used by the EthicalAds team.
 tags: privacy, community
-authors: Ra Cohen
+authors: David Fischer & Ra Cohen
 image: /images/posts/data-privacy-day-2022.jpg
 image_credit: <span>Photo by <a href="https://unsplash.com/@marvelous?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Marvin Meyer</a> on <a href="https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a></span>
 
-January 28th is International Data Privacy Day!
+This week is Data Privacy Week!
 To celebrate, we're helping you take charge of your own data by sharing some of our favorite privacy-first services.
 
 ## Web Browsers
 
 With over 63% of the browser market across devices,
 Google Chrome is currently and overwelmingly the dominant web browser.
-I myself used their bleeding edge build, Canary, for over a decade.
-As Chrome grew, however, I've become more conscious of the analytics, user profiling,
-and other privacy intrusions built into Chrome.
+As Chrome grew, however, people became more conscious of the analytics, user profiling,
+and other privacy intrusions built into it.
 Maybe allowing a mega-corporation to know every single intimate detail of my life
 isn't necessarily a good thing. Who knew?
 Lucky for decades-long former Chrome users, there's another Chrome build which doesn't funnel
 everything you've ever looked at back to the mothership.
 
-The open source [Chromium](https://www.chromium.org/Home/) is actually the code upon which Chrome is built.
+The open source [Chromium](https://www.chromium.org/) is actually the code upon which Chrome is built.
 Google maintains the codebase, documentation, and [download site](https://download-chromium.appspot.com/),
 but as open source projects are wont to do,
 Chromium has expanded into hundreds if not thousands of splinter projects and companies.
 There's an entire section on the Chromium wikipedia page featuring the largest [browsers based on Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)#Browsers_based_on_Chromium).
-Many of which are privacy-focused browsers like [Vivaldi](https://vivaldi.com/) and the [Avast Secure Browser](https://www.avast.com/secure-browser).
-Amusingly, some of these browsers were originally created independently and have since swapped over to being chromium-based.
-Some now chromium browsers older than Google itself like [Opera](https://www.opera.com/) which predates Google by 3 years.
-Personally, I enjoy Opera's side-tab features that let me have things like my music
-or discord open without the need for another window.
-Plus my tracker-blocker supports Opera so win-win!
+Many of which are privacy-focused browsers like [Brave](https://brave.com/),
+[Vivaldi](https://vivaldi.com/) and the [Avast Secure Browser](https://www.avast.com/secure-browser).
+
+The EthicalAds team relies on Firefox and Chromium.
+On mobile, DuckDuckGo has a [mobile browser](https://duckduckgo.com/app)
+with some intelligent tracker blocking built-in to keep you safe.
 
 
 ## Ad Blockers
 
-I'd used [AdBlockPlus](https://adblockplus.org/) for years without much thought,
-before I joined EthicalAds and started considering the industry as a whole.
-It's a simple, effective service which allows you control over not only which websites are allowed to show ads,
+About as important as the browser itself, are the additional privacy add-ons
+that keep you safe from ads and trackers.
+Many people like myself used [AdBlockPlus](https://adblockplus.org/) for years without much thought.
+It's a simple, effective service which gives you control over not only which websites are allowed to show ads,
 but it even allows you to greenlist certain YouTube and Twitch channels to run their ads
 so you can support your favorite creators.
 The creators of AdBlockPlus have gone on to form the [Acceptable Ads Committee](https://acceptableads.com/about/)
 who's [Acceptable Ads Standard](https://acceptableads.com/standard/) we follow
-as we believe in their mission of creating a sustainable and fair compromise between user preference and creator monetization.
+as EthicalAds believes in their mission of creating a sustainable and fair compromise between user preference and creator monetization.
 
 However, by default AdBlockPlus permits "Acceptable Ads" that [use third-party tracking](https://help.getadblock.com/support/solutions/articles/6000224547-about-acceptable-ads-and-third-party-tracking/).
 The standard for an unacceptable ad is largely focused on how annoying an ad is to the user experience
 as opposed to the detrimental effects of [surveillance advertising](https://www.ethicalads.io/surveillance-advertising/?ref=data-privacy-day-2022) as a whole.
 
-As an alternative, my colleague David has instead been using [Privacy Badger](https://privacybadger.org/) for years.
+As an alternative, some of our team relies on [Privacy Badger](https://privacybadger.org/).
 Privacy Badger is a browser extension from the Electronic Frontier Foundation, that isn't even an ad blocker.
 It only blocks *trackers*.
 However, since most ad networks track users, it ends up blocking most ads (but not us).
@@ -58,8 +58,17 @@ Instead, it learns based on the sites you visit which sites are tracking you acr
 either blocks requests to those sites completely or just disables them from storing cookies or other storage like local storage.
 Privacy Badger is supported on Firefox, Chrome, Microsoft Edge, and Opera so if you're running one of those, definitely check it out.
 
+<div class="postimage text-center">
+  <img class="w-50 shadow-lg" src="{static}../images/posts/2022-privacy-badger-bing.png" alt="Results of the EFF's Privacy Badger run on the Bing homepage">
+  <p>Results of the EFF's Privacy Badger run on the Bing homepage</p>
+</div>
+
 
 ## Search Engines
+
+> Check out our posts from last year on
+> [the best search engines for your privacy]({filename}../posts/2022-best-search-engines-for-your-privacy.md)
+> and a [privacy teardown of common search engines]({filename}../posts/2022-privacy-teardown-search-engines.md).
 
 When thinking of privacy-first search engines,
 your first thought may be [DuckDuckGo](https://duckduckgo.com/) and for good reason.
@@ -72,27 +81,23 @@ Not to mention how DuckDuckGo's supported the movement financially with [over $1
 to privacy and competition organizations in 2021 alone.
 DuckDuckGo is obviously a great pick for any privacy-concious netizen.
 
-However I'd be remiss to not also bring to your attention the search engine that
-I've personally swapped to in the last year [Ecosia](https://www.ecosia.org/),
-the search engine that plants trees.
-Like DuckDuckGo, their ad serving provider is Microsoft but
-in 2018, Ecosia committed to becoming a privacy-friendly search engine.
-Searches are now encrypted and not stored permanently,
-and no data is sold to third-party advertisers.
-As mentioned in their [privacy policy](https://info.ecosia.org/privacy),
-Ecosia does not create personal profiles based on search history,
-nor does it use external tracking tools like Google Analytics.
-What I especially like is that they're incredibly transparent with regards to their finances,
-publishing a [financial report](https://blog.ecosia.org/ecosia-financial-reports-tree-planting-receipts/) every month,
-showing the breakdown of their revenue and
-calculating the exact percentage of their surplus being reinvested into the planet,
-over 80% this month!
-Anyways, I can now highly recommend Ecosia as a primary search engine,
-especially if climate change weighs on your concious as heavily as it does mine.
+However, there are a number of other great search engines that respect your privacy.
+Late last year, we did a [review]({filename}../posts/2022-best-search-engines-for-your-privacy.md)
+of a number of a number of search engines from a data privacy perspective.
+Between [Mojeek](https://www.mojeek.com/),
+[Brave Search](https://search.brave.com/), and [You.com's search engine](https://you.com/)
+(their developer-focused search engine [YouCode](https://you.com/code) is fantastic),
+there's a number of great alternatives to Google.
+
+<div class="postimage text-center">
+  <img class="w-75 shadow-lg" src="{static}../images/posts/2022-search-engine-privacy-youcom.png" alt="Details of Python's hashlib in YouCode search">
+  <p>Details of Python's hashlib in YouCode search</p>
+</div>
+
 
 ## Analytics
 
-As a crucial step in building our own privacy-first, [ethical marketing funnel](https://www.ethicalads.io/blog/2021/10/building-an-ethical-marketing-funnel/?ref=data-privacy-day-2022),
+As a crucial step in building our own privacy-first, [ethical marketing funnel]({filename}../posts/2021-marketing-funnel.md),
 we evaluated a number of Google Analytics alternatives.
 Specifically we wanted to support open-source organizations
 that specialize in anoniminity-preserving aggregation algorithms
@@ -118,21 +123,19 @@ This is where our second privacy-preserving analytics recommendation shines.
 [Simple Analytics](https://simpleanalytics.com/?ref=ethicalads-blog) is a privacy-first analytics product designed specifically for *developers*. Sound familiar?
 The resonance between the EthicalAds' [Our Ad Vision](https://www.ethicalads.io/advertising-vision/?ref=data-privacy-day-2022) and
 Simple Analytics' [Our Promise](https://simpleanalytics.com/our-promise) page is astounding.
-We've thus partnered together to further the growth of the privacy-first movement
-by supporting growing dev creators of all sizes to employ **free privacy-first analytics** on their sites.
-You can read more about our shared offer as well as how to sign up on our [partnership announcement blog post](https://www.ethicalads.io/blog/2021/11/ethicalads-providing-free-analytics-with-simple-analytics/?ref=data-privacy-day-2022).
 
 
 ## Conclusion
 
-Data Privacy Day is a fairly new holiday,
+Data privacy week is relatively new,
 but we are thrilled to be in the privacy-first movement,
 and happy to take the opportunity to shed a spotlight on some other privacy-first projects who are doing great things.
 We've only scratched the surface of the privacy-tech ecosystem here,
 but every single product discussed has been used by one of us at EthicalAds.
 
-
-
 Thanks again for being along with us on this journey to build an ethical ad network.
 Please [email us](mailto:ads@ethicalads.io) if you have any privacy-first products that we should check out,
 we always love to hear from you.
+
+
+**Note:** the first version of the post appeared in 2022 but it has been updated for 2023.

--- a/content/posts/2023-data-privacy-week.md
+++ b/content/posts/2023-data-privacy-week.md
@@ -39,7 +39,7 @@ About as important as the browser itself, are the additional privacy add-ons
 that keep you safe from ads and trackers.
 Many people like myself used [AdBlockPlus](https://adblockplus.org/) for years without much thought.
 It's a simple, effective service which gives you control over not only which websites are allowed to show ads,
-but it even allows you to greenlist certain YouTube and Twitch channels to run their ads
+but it even allows you to allow list certain YouTube and Twitch channels to run their ads
 so you can support your favorite creators.
 The creators of AdBlockPlus have gone on to form the [Acceptable Ads Committee](https://acceptableads.com/about/)
 who's [Acceptable Ads Standard](https://acceptableads.com/standard/) we follow


### PR DESCRIPTION
This is dated to go out on Monday.

- Link to our search engine teardown
- Mention DDG's mobile browser with tracker blocking
- Mention Brave search and browser
- Re-use some screenshots from our search engine teardown

After launching, create a redirect from the old post (`https://www.ethicalads.io/blog/2022/01/data-privacy-day-2022-6-privacy-first-alternatives/`) to this one.


## Screenshot

![Screenshot 2023-01-20 at 15-57-50 Data Privacy Week 2023 - Privacy-first Alternatives](https://user-images.githubusercontent.com/185043/213825547-cf5573a4-32be-4dfb-8d94-0d74bd5d996c.png)
