### PR TITLE
More SEO fixes

### DIFF
--- a/content/pages/vs-carbon-ads.md
+++ b/content/pages/vs-carbon-ads.md
@@ -1,5 +1,5 @@
 Title: What Makes EthicalAds a Great Carbon Ads Alternative for Your Site
-slug: alternative-to-carbon-ads/
+slug: alternative-to-carbon-ads
 description: How are we different? Privacy guarantees, open source code, and community-focus.
 
 We know that we are competing with a few other ad networks that focus on developers.

--- a/content/pages/vs-carbon-ads.md
+++ b/content/pages/vs-carbon-ads.md
@@ -1,6 +1,5 @@
 Title: What Makes EthicalAds a Great Carbon Ads Alternative for Your Site
 slug: alternative-to-carbon-ads/
-save_as: alternative-to-carbon-ads/index.html
 description: How are we different? Privacy guarantees, open source code, and community-focus.
 
 We know that we are competing with a few other ad networks that focus on developers.

--- a/content/pages/vs-carbon-ads.md
+++ b/content/pages/vs-carbon-ads.md
@@ -1,5 +1,5 @@
 Title: What Makes EthicalAds a Great Carbon Ads Alternative for Your Site
-url: alternative-to-carbon-ads/
+slug: alternative-to-carbon-ads/
 save_as: alternative-to-carbon-ads/index.html
 description: How are we different? Privacy guarantees, open source code, and community-focus.
 

--- a/content/pages/vs-google.md
+++ b/content/pages/vs-google.md
@@ -1,5 +1,5 @@
 Title: What Makes EthicalAds a Great Google AdSense Alternative
-url: alternative-to-google-ads
+slug: alternative-to-google-ads
 save_as: alternative-to-google-ads/index.html
 description: A few reasons that you should consider EthicalAds as a simple, open-source, privacy-first alternative to Google Ads
 

--- a/content/pages/vs-google.md
+++ b/content/pages/vs-google.md
@@ -1,6 +1,5 @@
 Title: What Makes EthicalAds a Great Google AdSense Alternative
 slug: alternative-to-google-ads
-save_as: alternative-to-google-ads/index.html
 description: A few reasons that you should consider EthicalAds as a simple, open-source, privacy-first alternative to Google Ads
 
 We often get asked why you should choose EthicalAds instead of an existing display network like Google AdSense.


### PR DESCRIPTION
Builds on https://github.com/readthedocs/ethicalads.io/pull/338.

So `url:` becomes the exact URL (with or without the ending `/`). That's what we want when the URL is a subpath (eg. `/advertisers/hiring/`). However, if only the slug is specified, the URL becomes `/{slug}/` with the ending `/`. This is what we want for top level pages like these fixed here.