### PR TITLE
Change the rounding in the calculator

### DIFF
--- a/static-src/views/advertiser-calculator.js
+++ b/static-src/views/advertiser-calculator.js
@@ -58,7 +58,7 @@ function AdvertiserCalculatorViewModel() {
   };
 
   this.getNumImpressions = function () {
-    return this.budget() * 1000 / this.getCpm();
+    return this.budget() * 1000 / (Math.trunc(this.getCpm() * 100) / 100);
   };
 
   this.getNumClicks = function () {


### PR DESCRIPTION
The CPM was calculated as float with many decimal places. A buy at $4.45 with 10% off, for example, is $4.005 which causes some rounding oddities.

This change basically truncates the CPM in the advertiser's favor at 2 decimals.