### PR TITLE
Add a real ad served by the client back to the homepage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ You can build the site HTML and serve it locally with:
     $ inv rebuild         # build one time
     $ inv regenerate      # regenerate the site whenever you modify a page/post
     $ inv serve           # serve the site at http://localhost:8000
+    $ inv livereload      # Rebuild and serve the site on http://localhost:8000
 
 If you don't see any styling, you may also need to build static assets (see below).
 

--- a/ethicalads-theme/templates/ea/homepage.html
+++ b/ethicalads-theme/templates/ea/homepage.html
@@ -116,7 +116,7 @@
         <div class="text-center">
           {% include 'ea/includes/ad-placement.html' %}
         </div>
-        <!-- <p class="small text-muted text-center">(This is a real ad from our network)</p> -->
+          <p class="small text-muted text-center">(This is a real ad from our network)</p>
       </div>
 
     </div> <!-- / .row -->

--- a/ethicalads-theme/templates/ea/includes/ad-placement.html
+++ b/ethicalads-theme/templates/ea/includes/ad-placement.html
@@ -1,1 +1,1 @@
-<div data-ea-publisher="ethicaladsio" data-ea-type="image"></div>
+<div data-ea-publisher="ethicaladsio" data-ea-type="image" data-ea-campaign-types="house"></div>

--- a/ethicalads-theme/templates/ea/includes/ad-placement.html
+++ b/ethicalads-theme/templates/ea/includes/ad-placement.html
@@ -1,7 +1,1 @@
-<!-- Not using an EA ad now, using a screenshot of a real ad...
-<div data-ea-publisher="ethicaladsio" data-ea-type="image" data-ea-campaign-types="house"></div>
--->
-
-<div class="text-center">
-<img src="/theme/img/example-ads/example1.png" alt="A real ad we might run" class="img-fluid mw-50 float-right mb-6 mb-md-0" data-aos="fade-right" style="height: 223px;">
-</div>
+<div data-ea-publisher="ethicaladsio" data-ea-type="image"></div>


### PR DESCRIPTION
This is currently using a house ad since that's all that's approved on the EA Publisher.
Once we ship the campaign forcing, we can swap it to a real ad.

However, I think what we want is a rotation of paid ads,
but that aren't billed?

I guess we could use something like `random.choice(['mongodb', 'sentry', 'digital-ocean']` or something in the template to get a reasonable approach to start? 
