### PR TITLE
Initial refactor of publisher landing pages

### DIFF
--- a/ethicalads-theme/templates/ea/about.html
+++ b/ethicalads-theme/templates/ea/about.html
@@ -52,7 +52,6 @@
             <p>Since no existing ad networks would partner with us on privacy-respecting ads, we built our own.</p>
 
           </div>
-          
         </div>
 
       </div>

--- a/ethicalads-theme/templates/ea/about.html
+++ b/ethicalads-theme/templates/ea/about.html
@@ -52,6 +52,7 @@
             <p>Since no existing ad networks would partner with us on privacy-respecting ads, we built our own.</p>
 
           </div>
+          
         </div>
 
       </div>

--- a/ethicalads-theme/templates/ea/publishers.html
+++ b/ethicalads-theme/templates/ea/publishers.html
@@ -134,6 +134,58 @@
 </section>
 
 
+<!-- Subpage/topics callout
+================================================== -->
+<section class="py-10" id="audiences">
+  <div class="container">
+
+    <h2 class="text-center font-weight-bold mb-8">Publisher Topics</h2>
+    <p class="text-center lead">We focus on a number of different areas for our publishers, allowing our advertisers to target your developer audience.</p>
+
+    <div class="row">
+
+      <!-- Frontend web -->
+      <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up">
+        <div class="icon text-primary mb-3">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M18.5 8a2.5 2.5 0 110-5 2.5 2.5 0 010 5zm0 13a2.5 2.5 0 110-5 2.5 2.5 0 010 5zm-13 0a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" fill="#335EEA" opacity=".3"></path><path d="M5.5 8a2.5 2.5 0 110-5 2.5 2.5 0 010 5zM11 4h2a1 1 0 010 2h-2a1 1 0 010-2zm0 14h2a1 1 0 010 2h-2a1 1 0 010-2zm-6-8a1 1 0 011 1v2a1 1 0 01-2 0v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-2 0v-2a1 1 0 011-1z" fill="#335EEA"></path></g></svg>
+        </div>
+        <h3>Frontend web & Javascript developers</h3>
+        <p class="small"><a href="/publishers/topics/web-developers">Learn more</a></p>
+      </div>
+
+      <!-- Backend web -->
+      <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up" data-aos-delay="50">
+        <div class="icon text-primary mb-3">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M9 15H7.5A1.5 1.5 0 109 16.5V15zm0 0V9h6v6H9zm6 1.5a1.5 1.5 0 101.5-1.5H15v1.5zM16.5 9A1.5 1.5 0 1015 7.5V9h1.5zM9 7.5A1.5 1.5 0 107.5 9H9V7.5zm2 5.5h2v-2h-2v2zm2-2V7.5a3.5 3.5 0 113.5 3.5H13zm3.5 2a3.5 3.5 0 11-3.5 3.5V13h3.5zM11 16.5A3.5 3.5 0 117.5 13H11v3.5zM7.5 11A3.5 3.5 0 1111 7.5V11H7.5z" fill="#335EEA"></path></g></svg>
+        </div>
+        <h3>Backend web & Python developers</h3>
+        <p class="small"><a href="/publishers/topics/python/">Learn more</a></p>
+      </div>
+
+      <!-- Data Science -->
+      <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up" data-aos-delay="100">
+        <div class="icon text-primary mb-3">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><rect fill="#335EEA" opacity=".3" x="7" y="4" width="3" height="13" rx="1.5"></rect><rect fill="#335EEA" opacity=".3" x="12" y="9" width="3" height="8" rx="1.5"></rect><path d="M5 19h15a1 1 0 010 2H4a1 1 0 01-1-1V4a1 1 0 112 0v15z" fill="#335EEA"></path><rect fill="#335EEA" opacity=".3" x="17" y="11" width="3" height="6" rx="1.5"></rect></g></svg>
+        </div>
+        <h3>Data scientists</h3>
+        <p class="small"><a href="/publishers/topics/data-science/">Learn more</a></p>
+      </div>
+
+      <!-- DevOps -->
+      <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up" data-aos-delay="100">
+        <div class="icon text-primary mb-3">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M18.622 9.75h.128a2.25 2.25 0 110 4.5h-.065a.488.488 0 00-.446.295.488.488 0 00.089.54l.045.044a2.25 2.25 0 11-3.183 3.184l-.04-.04a.49.49 0 00-.545-.094.486.486 0 00-.295.444v.127a2.25 2.25 0 11-4.5 0 .524.524 0 00-.363-.514.485.485 0 00-.532.092l-.044.045a2.25 2.25 0 11-3.184-3.183l.04-.04a.49.49 0 00.094-.545.486.486 0 00-.443-.295H5.25a2.25 2.25 0 110-4.5.524.524 0 00.514-.363.485.485 0 00-.092-.532l-.045-.044A2.25 2.25 0 118.81 5.687l.04.04c.142.139.355.177.537.097l.108-.023a.486.486 0 00.255-.423V5.25a2.25 2.25 0 114.5 0v.065c0 .194.117.37.303.449.182.08.395.042.532-.092l.044-.045a2.25 2.25 0 113.184 3.183l-.04.04a.488.488 0 00-.097.537l.023.108a.486.486 0 00.423.255z" fill="#335EEA" opacity=".3"></path><path d="M12 15a3 3 0 100-6 3 3 0 000 6z" fill="#335EEA"></path></g></svg>
+        </div>
+        <h3>Open source developers</h3>
+        <p class="small"><a href="/publishers/topics/open-source/">Learn more</a></p>
+      </div>
+
+    </div> <!-- / .row -->
+
+    <p class="text-center">Interested in how our audience classifier works? <a href="/blog/2022/11/a-new-approach-to-content-based-targeting-for-advertising/">Read all about it</a>!</p>
+  </div> <!-- / .container -->
+</section>
+
 {% include 'ea/includes/publisher-testimonials.html' %}
 
 {% include 'ea/includes/publishers-inbound.html' %}

--- a/ethicalads-theme/templates/ea/publishers.html
+++ b/ethicalads-theme/templates/ea/publishers.html
@@ -139,8 +139,8 @@
 <section class="py-10" id="audiences">
   <div class="container">
 
-    <h2 class="text-center font-weight-bold mb-8">Publisher Topics</h2>
-    <p class="text-center lead">We focus on a number of different areas for our publishers, allowing our advertisers to target your developer audience.</p>
+    <h2 class="text-center font-weight-bold mb-8">Developer Audiences</h2>
+    <p class="text-center lead">We focus on different developer personas using our ML-based ad targeting for each audience</p>
 
     <div class="row">
 
@@ -149,7 +149,7 @@
         <div class="icon text-primary mb-3">
           <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M18.5 8a2.5 2.5 0 110-5 2.5 2.5 0 010 5zm0 13a2.5 2.5 0 110-5 2.5 2.5 0 010 5zm-13 0a2.5 2.5 0 110-5 2.5 2.5 0 010 5z" fill="#335EEA" opacity=".3"></path><path d="M5.5 8a2.5 2.5 0 110-5 2.5 2.5 0 010 5zM11 4h2a1 1 0 010 2h-2a1 1 0 010-2zm0 14h2a1 1 0 010 2h-2a1 1 0 010-2zm-6-8a1 1 0 011 1v2a1 1 0 01-2 0v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-2 0v-2a1 1 0 011-1z" fill="#335EEA"></path></g></svg>
         </div>
-        <h3>Frontend web & Javascript developers</h3>
+        <h3>Frontend web / Javascript developers</h3>
         <p class="small"><a href="/publishers/topics/web-developers">Learn more</a></p>
       </div>
 
@@ -158,7 +158,7 @@
         <div class="icon text-primary mb-3">
           <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M9 15H7.5A1.5 1.5 0 109 16.5V15zm0 0V9h6v6H9zm6 1.5a1.5 1.5 0 101.5-1.5H15v1.5zM16.5 9A1.5 1.5 0 1015 7.5V9h1.5zM9 7.5A1.5 1.5 0 107.5 9H9V7.5zm2 5.5h2v-2h-2v2zm2-2V7.5a3.5 3.5 0 113.5 3.5H13zm3.5 2a3.5 3.5 0 11-3.5 3.5V13h3.5zM11 16.5A3.5 3.5 0 117.5 13H11v3.5zM7.5 11A3.5 3.5 0 1111 7.5V11H7.5z" fill="#335EEA"></path></g></svg>
         </div>
-        <h3>Backend web & Python developers</h3>
+        <h3>Backend web / Python developers</h3>
         <p class="small"><a href="/publishers/topics/python/">Learn more</a></p>
       </div>
 
@@ -176,10 +176,16 @@
         <div class="icon text-primary mb-3">
           <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M18.622 9.75h.128a2.25 2.25 0 110 4.5h-.065a.488.488 0 00-.446.295.488.488 0 00.089.54l.045.044a2.25 2.25 0 11-3.183 3.184l-.04-.04a.49.49 0 00-.545-.094.486.486 0 00-.295.444v.127a2.25 2.25 0 11-4.5 0 .524.524 0 00-.363-.514.485.485 0 00-.532.092l-.044.045a2.25 2.25 0 11-3.184-3.183l.04-.04a.49.49 0 00.094-.545.486.486 0 00-.443-.295H5.25a2.25 2.25 0 110-4.5.524.524 0 00.514-.363.485.485 0 00-.092-.532l-.045-.044A2.25 2.25 0 118.81 5.687l.04.04c.142.139.355.177.537.097l.108-.023a.486.486 0 00.255-.423V5.25a2.25 2.25 0 114.5 0v.065c0 .194.117.37.303.449.182.08.395.042.532-.092l.044-.045a2.25 2.25 0 113.184 3.183l-.04.04a.488.488 0 00-.097.537l.023.108a.486.486 0 00.423.255z" fill="#335EEA" opacity=".3"></path><path d="M12 15a3 3 0 100-6 3 3 0 000 6z" fill="#335EEA"></path></g></svg>
         </div>
-        <h3>Open source developers</h3>
-        <p class="small"><a href="/publishers/topics/open-source/">Learn more</a></p>
+        <h3>DevOps engineers</h3>
       </div>
 
+      <!-- Security & Privacy -->
+      <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up" data-aos-delay="100">
+        <div class="icon text-primary mb-3">
+          <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M0 0h24v24H0z"></path><path d="M12 3a8 8 0 018 8v10a1 1 0 01-1 1H5a1 1 0 01-1-1V11a8 8 0 018-8zm-3 7a3 3 0 000 6h6a3 3 0 000-6H9z" fill="#335EEA"></path><path d="M15 14a1 1 0 110-2 1 1 0 010 2zm-6 0a1 1 0 110-2 1 1 0 010 2z" fill="#335EEA" opacity=".3"></path></g></svg>
+        </div>
+        <h3>Security &amp; privacy engineers</h3>
+      </div> 
     </div> <!-- / .row -->
 
     <p class="text-center">Interested in how our audience classifier works? <a href="/blog/2022/11/a-new-approach-to-content-based-targeting-for-advertising/">Read all about it</a>!</p>

--- a/ethicalads-theme/templates/ea/publishers.html
+++ b/ethicalads-theme/templates/ea/publishers.html
@@ -142,7 +142,7 @@
     <h2 class="text-center font-weight-bold mb-8">Developer Audiences</h2>
     <p class="text-center lead">We focus on different developer personas using our ML-based ad targeting for each audience</p>
 
-    <div class="row">
+    <div class="row  justify-content-center">
 
       <!-- Frontend web -->
       <div class="col-12 col-md-6 col-lg-4 p-6 text-center" data-aos="fade-up">

--- a/ethicalads-theme/templates/includes/footer.html
+++ b/ethicalads-theme/templates/includes/footer.html
@@ -139,6 +139,9 @@
             <a href="https://ethical-ad-client.readthedocs.io/en/latest/" class="text-reset">Ad Client Documentation</a>
           </li>
           <li class="mb-3">
+            <a href="/publishers/topics/open-source/" class="text-reset">Open Source</a>
+          </li>
+          <li class="mb-3">
             <a href="https://server.ethicalads.io/" class="text-reset">Publisher Login</a>
           </li>
         </ul>

--- a/ethicalads-theme/templates/includes/footer.html
+++ b/ethicalads-theme/templates/includes/footer.html
@@ -105,6 +105,9 @@
             <a href="/advertisers/ad-design-and-specs/" class="text-reset">Creative Specs</a>
           </li>
           <li class="mb-3">
+            <a href="/publishers/list/" class="text-reset">Top Publishers</a>
+          </li>
+          <li class="mb-3">
             <a href="https://www.ethicalads.io/prospectus/ethicalads-advertiser-prospectus.pdf"
               class="text-reset">Advertiser Prospectus</a>
           </li>
@@ -113,16 +116,6 @@
           </li>
           <li class="mb-3">
             <a href="https://server.ethicalads.io/" class="text-reset">Advertiser Login</a>
-          </li>
-        </ul>
-        <h6 class="font-weight-bold text-uppercase text-gray-700">Comparisons</h6>
-
-        <ul class="list-unstyled text-muted mb-6 mb-md-8 mb-lg-0">
-          <li class="mb-3">
-            <a href="/alternative-to-google-ads/" class="text-reset">Google Ads Comparison</a>
-          </li>
-          <li class="mb-3">
-            <a href="/alternative-to-carbon-ads/" class="text-reset">Carbon Ads Comparison</a>
           </li>
         </ul>
 
@@ -137,9 +130,6 @@
         <!-- List -->
         <ul class="list-unstyled text-muted mb-6 mb-md-8 mb-lg-0">
           <li class="mb-3">
-            <a href="/publishers/list/" class="text-reset">Top Publishers</a>
-          </li>
-          <li class="mb-3">
             <a href="/publishers/faq/" class="text-reset">Publisher FAQ</a>
           </li>
           <li class="mb-3">
@@ -150,32 +140,6 @@
           </li>
           <li class="mb-3">
             <a href="https://server.ethicalads.io/" class="text-reset">Publisher Login</a>
-          </li>
-        </ul>
-
-        <!-- Heading -->
-        <h6 class="font-weight-bold text-uppercase text-gray-700">Publisher Topics</h6>
-
-        <!-- List -->
-        <ul class="list-unstyled text-muted mb-6 mb-md-8 mb-lg-0">
-          <li class="mb-3">
-            <a href="/publishers/topics/python/" class="text-reset">Python Publishers</a>
-          </li>
-
-          <li class="mb-3">
-            <a href="/publishers/topics/web-developers/" class="text-reset">Web Developer Publishers</a>
-          </li>
-
-          <li class="mb-3">
-            <a href="/publishers/topics/data-science/" class="text-reset">Data Science Publishers</a>
-          </li>
-
-          <li class="mb-3">
-            <a href="/publishers/topics/open-source/" class="text-reset">Open Source</a>
-          </li>
-
-          <li class="mb-3">
-            <a href="/sponsorship-platform/" class="text-reset">Sponsorship Platform (beta)</a>
           </li>
         </ul>
 
@@ -193,6 +157,12 @@
           <li class="mb-3">
             <a href="/learning-hub/" class="text-reset">Learning Hub</a>
           </li>
+          <li class="mb-3">
+            <a href="/alternative-to-google-ads/" class="text-reset">Google Ads Comparison</a>
+          </li>
+          <li class="mb-3">
+            <a href="/alternative-to-carbon-ads/" class="text-reset">Carbon Ads Comparison</a>
+          </li>
         </ul>
 
         <!-- Heading -->
@@ -204,10 +174,10 @@
             <a href="/about/" class="text-reset">About Us</a>
           </li>
           <li class="mb-3">
-            <a href="/contact/" class="text-reset">Contact Us</a>
+            <a href="/contact/" class="text-reset">Contact</a>
           </li>
           <li class="mb-3">
-            <a href="/community-ads/" class="text-reset">Community Ads</a>
+            <a href="/press/" class="text-reset">Press Kit</a>
           </li>
           <li class="mb-3">
             <a href="/privacy-policy/" class="text-reset">Privacy Policy</a>
@@ -215,10 +185,6 @@
           <li class="mb-3">
             <a href="/terms-of-service/" class="text-reset">Terms of Service</a>
           </li>
-          <li class="mb-3">
-            <a href="/press/" class="text-reset">Media Kit</a>
-          </li>
-
           <!--
           <li class="mb-3">
             <a href="/jobs/" class="text-reset">Jobs</a>


### PR DESCRIPTION
This moves the content onto the publisher page and out of the footer.
It only includes links for the topics we have landing pages for,
which is the approach we took previously on the advertiser side.

I think this is good context setting for publishers,
and we can work to build landing pages for each audience once we think it's useful. 

## Screenshot

![Screenshot 2023-07-19 at 2 40 10 PM](https://github.com/readthedocs/ethicalads.io/assets/25510/955511d6-9e53-44a8-a471-7853c03d7c9f)
