### PR TITLE
Link the 100 req/s post to the "truly viral" post

### DIFF
--- a/content/posts/2021-hundred-requests-per-second-with-django.md
+++ b/content/posts/2021-hundred-requests-per-second-with-django.md
@@ -7,6 +7,9 @@ image: /images/posts/2021-django-100-requests-second.jpg
 image_credit: <span>Photo by <a href="https://unsplash.com/@rockthechaos?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Kolleen Gladden</a> on <a href="https://unsplash.com/?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
 
 
+**In a followup post, we discuss a traffic spike to [200 requests per second]({filename}../posts/2023-going-truly-viral.md)!**
+
+
 Usually, our blog focuses on advertising, privacy,
 and our journey in building a business around the intersection of the two.
 This post is going to go under the hood and discuss some of the technology and scaling challenges

--- a/content/posts/2023-going-truly-viral.md
+++ b/content/posts/2023-going-truly-viral.md
@@ -1,7 +1,7 @@
 Title: What Happens When Elon Musk Tweets A Link To Your Service
 Date: September 19, 2023
 description: Back in February, we had a service degradation event resulting from a massive surge of viral traffic. This is a post-mortem about that near-downtime event.
-tags: community, analytics, performance, publishers
+tags: analytics, performance, publishers
 authors: David Fischer
 image: /images/posts/going-viral-2023.png
 


### PR DESCRIPTION
This just adds a small link between the two posts to drive traffic to the new post. It also adjusts a tag on the new post to ensure that the posts are linked at the bottom of "similar posts". Both are performance-related posts and the newer post already links to the old.