### PR TITLE
Add auto-renewing language to site

### DIFF
--- a/content/pages/advertising-faq.md
+++ b/content/pages/advertising-faq.md
@@ -14,6 +14,8 @@ Our [prices](/advertisers/#pricing) differ by topic and by geography and rates c
 Ads are priced in cost per thousand impressions (CPM) and
 we also offer an automatic 10% discount for ad buys of $3,000,
 and 15% for ad buys of $25,000 or more.
+You may also opt-in to have your campaign renew automatically
+for an additional 10% discount.
 
 While you might setup a recurring campaign to be billed monthly,
 all our pricing is per impression.

--- a/ethicalads-theme/templates/ea/advertisers-calculator.html
+++ b/ethicalads-theme/templates/ea/advertisers-calculator.html
@@ -44,7 +44,7 @@
 
           <div class="form-group mb-8">
             <h3>Campaign budget</h3>
-            <p class="small">This budget could be over just a few weeks or as long as a quarter. There is an automatic discount of 10% for campaigns over $3k and 15% for campaigns over $25k.</p>
+            <p class="small">This budget could be over just a few weeks or as long as a quarter. There is an automatic discount of 10% for campaigns over $3k and 15% for campaigns over $25k. Set your monthly or quarterly campaign to renew automatically and receive an additional 10% discount.</p>
 
             <div class="d-print-none">
               <div class="input-group input-group-sm mx-auto w-50 w-lg-25">
@@ -59,6 +59,15 @@
                 <div class="small flex-fill">$500</div>
                 <div class="small flex-fill text-right">$25k</div>
               </div>
+
+              <div class="form-check mt-5 text-right">
+                <input class="form-check-input" type="checkbox" value="" id="autorenewing" data-bind="checked: autorenewing">
+                <label class="form-check-label" for="autorenewing">
+                  Auto-renewing
+                </label>
+              </div>
+
+
             </div>
           </div>
 
@@ -134,6 +143,7 @@
             <p class="lead mb-0" data-bind="text: '$' + getCpm().toFixed(2)"></p>
             <p class="small mb-0" data-bind="if: budget() >= 3000 && budget() < 25000">* 10% discount applied</p>
             <p class="small mb-0" data-bind="if: budget() >= 25000">* 15% discount applied</p>
+            <p class="small mb-0" data-bind="if: autorenewing()">* 10% auto-renewal discount</p>
           </div>
           <div class="flex-fill text-center mb-5">
             <p class="small mb-0">Number of impressions</p>

--- a/ethicalads-theme/templates/ea/includes/packages.html
+++ b/ethicalads-theme/templates/ea/includes/packages.html
@@ -5,7 +5,7 @@
         <h2 class="text-center font-weight-bold mb-4">Pricing for Q2 2024</h2>
         <p class="text-center">Prices are per thousand impressions (CPM) with a $1,000 minimum ad buy.</p>
         <p class="text-center">For other region prices or customizations, see our <a href="/prospectus/ethicalads-advertiser-prospectus.pdf">prospectus</a> or try our <a href="/advertisers/calculator/">campaign calculator</a>.</p>
-        <p class="text-center">We offer an automatic 10% discount for ad buys of $3,000 and 15% for $25,000.</p>
+        <p class="text-center">We offer a 10% discount for ad buys of $3,000 and 15% for $25,000. 10% additional discount for auto-renewing campaigns.</p>
       </div>
     </div>
 

--- a/static-src/views/advertiser-calculator.js
+++ b/static-src/views/advertiser-calculator.js
@@ -56,6 +56,10 @@ function AdvertiserCalculatorViewModel() {
     } else if (this.budget() >= 3000) {
       cpm = cpm * 0.9;
     }
+    if (this.autorenewing()) {
+      // 10% discount for auto-renewing
+      cpm = cpm * 0.9;
+    }
     return cpm;
   };
 
@@ -78,6 +82,7 @@ function AdvertiserCalculatorViewModel() {
       budget: this.budget(),
       region: this.selected_region(),
       topic: this.selected_topic(),
+      autorenewing: this.autorenewing(),
     });
     return url + "?" + searchParams.toString();
   };
@@ -89,6 +94,7 @@ function AdvertiserCalculatorViewModel() {
       "budget": this.getBudget(),
       "region": this.selected_region(),
       "topic": this.selected_topic(),
+      "autorenewing": this.autorenewing(),
     };
 
     window.history.pushState(state, null, url);
@@ -103,15 +109,17 @@ function AdvertiserCalculatorViewModel() {
   let initial_budget = parseInt(params.get("budget"), 10) || 1000;
   let initial_region = this.validateRegion(params.get("region")) || "blend";
   let initial_topic = this.validateTopic(params.get("topic")) || "all-developers";
+  let initial_autorenewing = Boolean(params.get("autorenewing")) || false;
 
   this.selected_region = ko.observable(initial_region);
   this.selected_topic = ko.observable(initial_topic);
   this.budget = ko.observable(initial_budget);
+  this.autorenewing = ko.observable(initial_autorenewing);
 
   this.ctr = ko.observable(0.12);
   this.conversion_rate = ko.observable(5.0);
 
-  // On changes to the region, topic, or budget,
+  // On changes to the region, topic, autorenew, or budget,
   // push the state to the browser's history API
   // This updates the URL in the URL bar without reloading the page
   this.selected_region.subscribe(function () {
@@ -121,6 +129,9 @@ function AdvertiserCalculatorViewModel() {
     this.setUrlState();
   }, this);
   this.budget.subscribe(function () {
+    this.setUrlState();
+  }, this);
+  this.autorenewing.subscribe(function () {
     this.setUrlState();
   }, this);
 }


### PR DESCRIPTION
- Advertisers FAQ
- Calculator
- Pricing page/section

I don't love the copy to be honest. I feel like it can be improved but I want a short way to say that auto-renewing is opt-in but that you get a discount for it.