### PR TITLE
Make the testimonials into a carousel

### DIFF
--- a/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
+++ b/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
@@ -10,84 +10,87 @@
   </div>
 
 
-  <div class="card-deck">
+  <div class="main-carousel" data-flickity='{"autoPlay": true, "wrapAround": true, "pageDots": true, "prevNextButtons": true}'>
 
     <!-- Triplebyte -->
-    <div class="card card-border shadow-light-lg" style="border-top-color: #4a90e2;">
-      <div class="card-body text-center">
+    <div class="carousel-cell col-12 col-md-9">
+      <div class="card card-border shadow-light-lg" style="border-top-color: #4a90e2;">
+        <div class="card-body text-center">
 
-        <!-- Text -->
-        <p class="text-gray-700 mb-5 small">"EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers."</p>
+          <!-- Text -->
+          <p class="text-gray-700 mb-5 lead">"EthicalAds has been a great way to directly get Triplebyte in front of job-seeking developers."</p>
 
-        <!-- Photo -->
-        <div class="img-fluid mb-5 w-25 mx-auto">
-          <img class="rounded-circle" src="/images/pages/testimonials/triplebyte-amy.jpg" alt="Amy Dwarnick from Triplebyte" />
+          <!-- Photo -->
+          <div class="img-fluid mb-5 w-25 mx-auto">
+            <img class="rounded-circle" src="/images/pages/testimonials/triplebyte-amy.jpg" alt="Amy Dwarnick from Triplebyte" />
+          </div>
+
+          <h5 class="small text-muted">Amy @ Triplebyte</h5>
+
+
+          <!-- Link -->
+          <div class="mt-5">
+            <a href="/advertisers/triplebyte/">Triplebyte case study &raquo;</a>
+          </div>
+
         </div>
-
-        <h5 class="small text-muted">Amy @ Triplebyte</h5>
-
-
-        <!-- Link -->
-        <div class="mt-5">
-          <a href="/advertisers/triplebyte/">Triplebyte case study &raquo;</a>
-        </div>
-
       </div>
     </div>
-
-
 
     <!-- SuperOrbital -->
-    <div class="card card-border shadow-light-lg" style="border-top-color: #e8911a;">
-      <div class="card-body text-center">
+    <div class="carousel-cell col-12 col-md-9">
+      <div class="card card-border shadow-light-lg" style="border-top-color: #e8911a;">
+        <div class="card-body text-center">
 
-        <!-- Text -->
-        <p class="text-gray-700 mb-5 small">"Seriously, EthicalAds has been such a pleasure to work with!"</p>
+          <!-- Text -->
+          <p class="text-gray-700 mb-5 lead">"Seriously, EthicalAds has been such a pleasure to work with!"</p>
 
-        <!-- Line up the text with the photo -->
-        <br>
+          <br> <!-- Line up the text with the photo -->
 
-        <!-- Photo -->
-        <div class="img-fluid mb-5 w-25 mx-auto">
-          <img class="rounded-circle" src="/images/pages/testimonials/superorbital-lexi.jpg" alt="Lexi Lambert from SuperOrbital" />
+          <!-- Photo -->
+          <div class="img-fluid mb-5 w-25 mx-auto">
+            <img class="rounded-circle" src="/images/pages/testimonials/superorbital-lexi.jpg" alt="Lexi Lambert from SuperOrbital" />
+          </div>
+
+          <h5 class="small text-muted">Lexi @ SuperOrbital</h5>
+
+
+          <!-- Link -->
+          <div class="mt-5">
+            <a href="/advertisers/superorbital/">SuperOrbital case study &raquo;</a>
+          </div>
+
         </div>
-
-        <h5 class="small text-muted">Lexi @ SuperOrbital</h5>
-
-
-        <!-- Link -->
-        <div class="mt-5">
-          <a href="/advertisers/superorbital/">SuperOrbital case study &raquo;</a>
-        </div>
-
       </div>
     </div>
-
 
     <!-- Tidelift -->
-    <div class="card card-border shadow-light-lg" style="border-top-color: #4b5168;">
-      <div class="card-body text-center">
+    <div class="carousel-cell col-12 col-md-9">
+      <div class="card card-border shadow-light-lg" style="border-top-color: #4b5168;">
+        <div class="card-body text-center">
 
-        <!-- Text -->
-        <p class="text-gray-700 mb-5 small">"The CPL is much lower than other digital ads, and the audience is tailored to our mission."</p>
+          <!-- Text -->
+          <p class="text-gray-700 mb-5 lead">"The CPL is much lower than other digital ads, and the audience is tailored to our mission."</p>
 
-        <!-- Photo -->
-        <div class="img-fluid mb-5 w-25 mx-auto">
-          <img class="rounded-circle" src="/images/pages/testimonials/tidelift-amy.jpg" alt="Amy Hays from Tidelift" />
+          <!-- Photo -->
+          <div class="img-fluid mb-5 w-25 mx-auto">
+            <img class="rounded-circle" src="/images/pages/testimonials/tidelift-amy.jpg" alt="Amy Hays from Tidelift" />
+          </div>
+
+          <h5 class="small text-muted">Amy @ Tidelift</h5>
+
+
+          <!-- Link -->
+          <div class="mt-5">
+            <a href="/advertisers/tidelift/">Tidelift case study &raquo;</a>
+          </div>
+
         </div>
-
-        <h5 class="small text-muted">Amy @ Tidelift</h5>
-
-
-        <!-- Link -->
-        <div class="mt-5">
-          <a href="/advertisers/tidelift/">Tidelift case study &raquo;</a>
-        </div>
-
       </div>
     </div>
 
-  </div><!-- /.card-deck -->
+  </div> <!-- /.flickity -->
+
 
   <div class="py-5 mt-10">
     <h4 class="font-weight-bold mb-8 text-center">Looking for what kinds of ads worked well for other advertisers across our network?</h4>

--- a/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
+++ b/ethicalads-theme/templates/ea/includes/advertiser-testimonials.html
@@ -10,7 +10,7 @@
   </div>
 
 
-  <div class="main-carousel" data-flickity='{"autoPlay": true, "wrapAround": true, "pageDots": true, "prevNextButtons": true}'>
+  <div class="main-carousel" data-flickity='{"autoPlay": true, "wrapAround": true, "pageDots": true, "prevNextButtons": true, "autoPlay": 3000}'>
 
     <!-- Triplebyte -->
     <div class="carousel-cell col-12 col-md-9">

--- a/static-src/index.js
+++ b/static-src/index.js
@@ -35,8 +35,9 @@ import * as bootstrap from 'bootstrap';
 //import './landkit/js/fancybox.js';
 
 // Flickity is for flickable carousels
-//import * as flickity from 'flickity';
-//import * as flickityfade from 'flickity-fade';
+// Import flickity (horizontal scroll carousel)
+import * as flickity from 'flickity';
+import * as flickityfade from 'flickity-fade';
 
 // HighlightJS is for syntax highlighting
 // I'm not sure what Landkit uses it for

--- a/static-src/scss/index.scss
+++ b/static-src/scss/index.scss
@@ -24,6 +24,10 @@
 
 // Feather Icon pack
 @import '../landkit/fonts/Feather/feather.css';
+
+// Import flickity (horizontal scroll carousel)
+@import '~flickity/dist/flickity.min.css';
+@import '~flickity-fade/flickity-fade.css';
 ////////////////////////////////////////////////////////////////////////////
 // End Landkit
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The testimonials are in a carousel. There's a bunch of [options](https://flickity.metafizzy.co/options) but I made a few choices:

- I have it autoscrolling with the default 3s interval (we can force users to scroll manually or autoscroll at a different interval)
- We have buttons to scroll (these can be styled or removed)
- There's the dots at the bottom to indicate how many (this can be turned off)
- The width of scrolling items is configurable. I went with 75% of screen size at big screen sizes.

Before I start refactoring which testimonials to show, I wanted to get some feedback on this so far.

## Screenshot
![Screenshot from 2024-07-17 15-38-55](https://github.com/user-attachments/assets/667f02b2-7090-43ec-8d2b-d1c15ba41a7d)
