### PR TITLE
Add calculator button to pricing

### DIFF
--- a/ethicalads-theme/templates/ea/includes/packages.html
+++ b/ethicalads-theme/templates/ea/includes/packages.html
@@ -92,8 +92,12 @@
     </div> <!-- / .row -->
 
     <p class="text-center py-5">
-      <a href="/advertisers/#inbound-form" class="btn btn-primary lift">
+      <a href="/advertisers/#inbound-form" class="btn btn-primary lift m-3">
         <span>Start a campaign</span>
+      </a>
+
+      <a href="/advertisers/calculator/" class="btn btn-primary-soft lift m-3">
+        <span>Plan your campaign</span>
       </a>
     </p>
   </div>


### PR DESCRIPTION
Adds a "plan your campaign" button under pricing both on the [advertisers page](https://www.ethicalads.io/advertisers/) and on the [pricing page](https://www.ethicalads.io/advertisers/pricing/).


<img width="2288" height="1609" alt="image" src="https://github.com/user-attachments/assets/336210a7-234d-4716-9bdb-cb8c3acc99a2" />


<img width="842" height="1118" alt="image" src="https://github.com/user-attachments/assets/b8ace5b6-37c1-485e-9e21-7431d6fc047c" />
